### PR TITLE
releng: Add github workflow for continuous integration (2021-06 branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: 
+      - master
+      - stable-*
+      - 2021-06
+  pull_request:
+    branches:
+      - master
+      - stable-*
+      - 2021-06
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Copy legacy files
+      run: |
+         cp -f ./rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy/tracing.incubator.product ./rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product
+         cp -f ./trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy/traceserver.product ./trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.5
+    - name: Build with Maven
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: >- 
+        mvn -B clean install -Dtarget-platform=tracecompass-incubator-e4.20 -Djdk.version=11 -Djdk.release=11 -Dtycho-use-project-settings=false
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: build logs
+        path: |
+          */*tests/screenshots/*.jpeg
+          */*tests/target/work/data/.metadata/.log
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test results
+        path: |
+          */*/target/surefire-reports/*.xml


### PR DESCRIPTION
Add following workflow file: ci.yml for 2021-06 branch. It uses different maven command-line parameters and copies the legacy product files for RCP and Trace Server before running the maven build.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>