### PR TITLE
ros2: support pub-sub message tracking using rmw layer only

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/Ros2Trace.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/Ros2Trace.java
@@ -25,10 +25,16 @@ import org.eclipse.tracecompass.incubator.internal.ros2.core.trace.layout.IRos2E
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.event.aspect.ITmfEventAspect;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfTraceException;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfContext;
 import org.eclipse.tracecompass.tmf.core.trace.TraceValidationStatus;
+import org.eclipse.tracecompass.tmf.ctf.core.context.CtfLocation;
+import org.eclipse.tracecompass.tmf.ctf.core.context.CtfLocationInfo;
+import org.eclipse.tracecompass.tmf.ctf.core.context.CtfTmfContext;
+import org.eclipse.tracecompass.tmf.ctf.core.event.CtfTmfEvent;
 import org.eclipse.tracecompass.tmf.ctf.core.event.CtfTmfEventFactory;
 import org.eclipse.tracecompass.tmf.ctf.core.trace.CtfTmfTrace;
 import org.eclipse.tracecompass.tmf.ctf.core.trace.CtfTraceValidationStatus;
+import org.osgi.framework.Version;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -51,9 +57,16 @@ public class Ros2Trace extends CtfTmfTrace {
         ROS_ASPECTS = builder.build();
     }
 
+    /**
+     * Last version before the 'version' field was added. As it turns out, the
+     * field was added in 0.1.0.
+     */
+    private static final @NonNull String TRACETOOLS_VERSION_UNKNOWN = "0.0.0"; //$NON-NLS-1$
+
     private @NonNull Collection<ITmfEventAspect<?>> fRos2TraceAspects = ImmutableSet.copyOf(ROS_ASPECTS);
 
     private @Nullable IRos2EventLayout fLayout = null;
+    private @Nullable Version fTracetoolsVersion = null;
 
     /**
      * Default constructor
@@ -86,19 +99,69 @@ public class Ros2Trace extends CtfTmfTrace {
         return layout;
     }
 
+    /**
+     * @return the version of the ROS 2 tracetools package used to generate the
+     *         trace
+     */
+    public @NonNull Version getTracetoolsVersion() {
+        Version tracetoolsVersion = fTracetoolsVersion;
+        if (null == tracetoolsVersion) {
+            throw new IllegalStateException("Cannot get the tracetools version of a non-initialized trace"); //$NON-NLS-1$
+        }
+        return tracetoolsVersion;
+    }
+
     @Override
     public void initTrace(IResource resource, String path,
             Class<? extends ITmfEvent> eventType) throws TmfTraceException {
         super.initTrace(resource, path, eventType);
 
         // Determine the event layout to use
-        IRos2EventLayout layout = getLayout();
-        fLayout = layout;
+        fLayout = getLayout();
+        fTracetoolsVersion = getTracetoolsVersion(fLayout);
     }
 
     private static @NonNull IRos2EventLayout getLayout() {
         // Only one layout for the moment
         return Objects.requireNonNull(IRos2EventLayout.getDefault());
+    }
+
+    private @NonNull Version getTracetoolsVersion(IRos2EventLayout layout) {
+        return getVersionFromEvent(layout.eventRclInit(), layout);
+    }
+
+    private @NonNull Version getVersionFromEvent(@NonNull String versionEventName, IRos2EventLayout layout) {
+        CtfTmfEvent event = seekEvent(versionEventName);
+        if (null == event) {
+            /**
+             * This could happen if the tracepoint is not enabled, in which case
+             * we just have to assume a version.
+             */
+            Activator.getInstance().logError("Cannot get event " + versionEventName); //$NON-NLS-1$
+            return new Version(TRACETOOLS_VERSION_UNKNOWN);
+        }
+        String versionStr = (String) event.getContent().getFieldValue(Object.class, layout.fieldVersion());
+        if (null == versionStr) {
+            /**
+             * If the event exists, but the field doesn't exist, default to the
+             * version right before the field was added.
+             */
+            return new Version(TRACETOOLS_VERSION_UNKNOWN);
+        }
+        return new Version(versionStr);
+    }
+
+    private @Nullable CtfTmfEvent seekEvent(@NonNull String eventName) {
+        // Seek the first event and then advance until we get the right event
+        CtfLocation location = new CtfLocation(new CtfLocationInfo(0L, 0L));
+        ITmfContext result = seekEvent(location);
+        CtfTmfContext context = (CtfTmfContext) result;
+        while (!context.getCurrentEvent().getName().equals(eventName)) {
+            if (!context.advance()) {
+                return null;
+            }
+        }
+        return context.getCurrentEvent();
     }
 
     @Override


### PR DESCRIPTION
The current implementation of the ROS 2 plugin relies on events from the underlying DDS middleware in order to be able to track a message from publication to subscription: it needs to get a timestamp value from DDS when a message is published. This timestamp value is then matched to the same value when the message is received on the other end.

While the ROS 2 instrumentation is available by default on Linux, instrumentation for the DDS implementation(s) is not available by default; the DDS implementation needs to be built from source. However, some recent changes to the ROS 2 instrumentation mean that DDS instrumentation is not needed anymore in order to track messages from publication to subscription. We just rely on events from the ROS 2 `rmw` layer (which is right above DDS in the ROS 2 architecture), specifically the `ros2:rmw_publish` events, to get the same timestamp. For more information about these changes, see: https://github.com/ros2/ros2_tracing/pull/74.

Therefore, note the version of the instrumentation (aka the ROS 2 `tracetools` package) used to generate the trace. If the version is greater than or equal to the version that contains the new changes, rely on `rmw` for the timestamp value. Otherwise, if an older version is used, rely on DDS for the timestamp value.