### PR TITLE
ftrace: improve binary parser speed by optimizing I/O

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core.tests/src/org/eclipse/tracecompass/incubator/ftrace/core/tests/binary/buffer/BinaryFTraceByteBufferTest.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core.tests/src/org/eclipse/tracecompass/incubator/ftrace/core/tests/binary/buffer/BinaryFTraceByteBufferTest.java
@@ -45,38 +45,37 @@ public class BinaryFTraceByteBufferTest {
         String traceLocation = FTraceUtils.getTraceAbsolutePath(FtraceTestTrace.TEST_2_6_MULTIPLE_CPUS);
         long currentOffset = 0;
 
-        try (BinaryFTraceByteBuffer buffer = new BinaryFTraceByteBuffer(traceLocation)) {
-            // Read the magic values
-            buffer.getNextBytes(BinaryFTraceHeaderElementSize.MAGIC_VALUE);
-            currentOffset += BinaryFTraceHeaderElementSize.MAGIC_VALUE;
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        BinaryFTraceByteBuffer buffer = new BinaryFTraceByteBuffer(traceLocation);
+        // Read the magic values
+        buffer.getNextBytes(BinaryFTraceHeaderElementSize.MAGIC_VALUE);
+        currentOffset += BinaryFTraceHeaderElementSize.MAGIC_VALUE;
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            String tracingString = buffer.getNextBytesAsString(BinaryFTraceHeaderElementSize.TRACING_STRING);
-            currentOffset += BinaryFTraceHeaderElementSize.TRACING_STRING;
-            assertEquals(tracingString, TRACING);
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        String tracingString = buffer.getNextBytesAsString(BinaryFTraceHeaderElementSize.TRACING_STRING);
+        currentOffset += BinaryFTraceHeaderElementSize.TRACING_STRING;
+        assertEquals(tracingString, TRACING);
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            String versionString = buffer.getNextString();
-            currentOffset += (BinaryFTraceHeaderElementSize.FTRACE_VERSION + BinaryFTraceHeaderElementSize.STRING_TERMINATOR);
-            assertEquals(versionString, VERSION);
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        String versionString = buffer.getNextString();
+        currentOffset += (BinaryFTraceHeaderElementSize.FTRACE_VERSION + BinaryFTraceHeaderElementSize.STRING_TERMINATOR);
+        assertEquals(versionString, VERSION);
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            // Read various data types and validate offset changes
-            buffer.getNextShort();
-            currentOffset += BinaryFTraceDataType.SHORT.getSize();
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        // Read various data types and validate offset changes
+        buffer.getNextShort();
+        currentOffset += BinaryFTraceDataType.SHORT.getSize();
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            buffer.getNextInt();
-            currentOffset += BinaryFTraceDataType.INT.getSize();
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        buffer.getNextInt();
+        currentOffset += BinaryFTraceDataType.INT.getSize();
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            buffer.getNextLong();
-            currentOffset += BinaryFTraceDataType.LONG.getSize();
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
+        buffer.getNextLong();
+        currentOffset += BinaryFTraceDataType.LONG.getSize();
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
 
-            buffer.movePointerToOffset(RANDOM_OFFSET);
-            currentOffset = RANDOM_OFFSET;
-            assertEquals(buffer.getCurrentOffset(), currentOffset);
-        }
+        buffer.movePointerToOffset(RANDOM_OFFSET);
+        currentOffset = RANDOM_OFFSET;
+        assertEquals(buffer.getCurrentOffset(), currentOffset);
     }
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceCPUSectionIterator.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceCPUSectionIterator.java
@@ -140,11 +140,8 @@ public class BinaryFTraceCPUSectionIterator implements AutoCloseable {
      * Get the current event of this iterator lazily.
      *
      * @return The current event as a BinaryFTrace event.
-     * @throws IOException
-     *             if there is an error reading the event, likely because of
-     *             byte buffer failure.
      */
-    public @Nullable BinaryFTraceEvent getCurrentEvent() throws IOException {
+    public @Nullable BinaryFTraceEvent getCurrentEvent() {
         BinaryFTraceCPUPageIterator iter = fCurrPageIterator;
         if (iter != null) {
             return iter.getCurrentEvent();

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceIterator.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceIterator.java
@@ -69,7 +69,7 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
      *            The {@link BinaryFTraceHeaderInfo} linked to the trace. It
      *            should be provided by the corresponding 'ctfTmfTrace'.
      * @param ftrace
-     *            The {@link BinaryFTraceDirectImp} to iterate over
+     *            The {@link BinaryFTrace} to iterate over
      * @throws IOException
      *             If the iterator couldn't not be instantiated, probably due to
      *             a read error.
@@ -95,12 +95,8 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
      *
      * @return GenericFtraceEvent The current event that the iterator currently
      *         points to; null if there are no more events in the trace.
-     * @throws IOException
-     *             If reading the next event fails, most likely because of
-     *             buffer overflow.
      */
-    @SuppressWarnings("resource")
-    public synchronized GenericFtraceEvent getCurrentEvent() throws IOException {
+    public synchronized GenericFtraceEvent getCurrentEvent() {
         final BinaryFTraceCPUSectionIterator top = super.getPrio().peek();
         if (top != null) {
             if (!fCurLocation.equals(fPreviousLocation)) {
@@ -175,10 +171,8 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
      *            The LocationData representing the position to seek to
      * @return True if the seek was successful, false if there was an error
      *         seeking.
-     * @throws IOException
-     *             If an error occurred while seeking the event
      */
-    public synchronized boolean seek(BinaryFTraceLocationInfo ctfLocationData) throws IOException {
+    public synchronized boolean seek(BinaryFTraceLocationInfo ctfLocationData) {
         if (ctfLocationData.equals(BinaryFTraceLocation.INVALID_LOCATION)) {
             fCurLocation = NULL_LOCATION;
             return false;
@@ -238,7 +232,7 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
         return seekSuccess;
     }
 
-    private long positionIteratorByIndex(long timestamp, long indexToSeek) throws IOException {
+    private long positionIteratorByIndex(long timestamp, long indexToSeek) {
         boolean success = true;
         long currentIndex = 0;
 
@@ -269,12 +263,12 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
     }
 
     @Override
-    public boolean advance() throws IOException {
+    public boolean advance() {
         boolean readNextEventSuccess = readNextEvent();
         return readNextEventSuccess && skipRawSystemEvents();
     }
 
-    private boolean readNextEvent() throws IOException {
+    private boolean readNextEvent() {
         boolean hasMoreEvents = false;
         try {
             hasMoreEvents = super.advance();
@@ -297,7 +291,7 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
         return hasMoreEvents;
     }
 
-    private boolean skipRawSystemEvents() throws IOException {
+    private boolean skipRawSystemEvents() {
         // Position the trace at the first non raw event
         GenericFtraceEvent event = getCurrentEvent();
 
@@ -310,7 +304,7 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
         return ret;
     }
 
-    private boolean skipToFirstValidEvent() throws IOException {
+    private boolean skipToFirstValidEvent() {
         // This means we are initializing the trace
         boolean initTrace = false;
         if (fCurLocation == null) {
@@ -373,11 +367,9 @@ public class BinaryFTraceIterator extends BinaryFTraceReader implements ITmfCont
      *
      * @return 0 if there is no more event to read; else return the current
      *         timestamp location.
-     * @throws IOException
-     *             if an error occurred while getting the event
      */
     @SuppressWarnings("resource")
-    public synchronized long getCurrentTimestamp() throws IOException {
+    public synchronized long getCurrentTimestamp() {
         final BinaryFTraceCPUSectionIterator top = super.getPrio().peek();
 
         if (top != null) {

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceIteratorHelper.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceIteratorHelper.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.tracecompass.incubator.internal.ftrace.core.binary.iterator;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -102,10 +101,8 @@ public class BinaryFTraceIteratorHelper {
      * @param headerInfo
      *            The trace header
      * @return The iterator to get events from this page
-     * @throws IOException
-     *             if an error occurs while creating the page iterator
      */
-    public static @Nullable BinaryFTraceCPUPageIterator getPageIterator(BinaryFTraceCPUDataPage page, BinaryFTraceHeaderInfo headerInfo) throws IOException {
+    public static @Nullable BinaryFTraceCPUPageIterator getPageIterator(BinaryFTraceCPUDataPage page, BinaryFTraceHeaderInfo headerInfo) {
         if (headerInfo != null && page != null) {
             return new BinaryFTraceCPUPageIterator(page, headerInfo);
         }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceReader.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/iterator/BinaryFTraceReader.java
@@ -304,10 +304,8 @@ public class BinaryFTraceReader implements AutoCloseable {
      * Go to the next event.
      *
      * @return True if an event was read.
-     * @throws IOException
-     *             if an error occurs
      */
-    public boolean advance() throws IOException {
+    public boolean advance() {
         /*
          * Remove the reader from the top of the priority queue.
          */

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/parser/AbstractBinaryFTraceFileParser.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/parser/AbstractBinaryFTraceFileParser.java
@@ -23,7 +23,6 @@ import static org.eclipse.tracecompass.incubator.internal.ftrace.core.binary.eve
 import static org.eclipse.tracecompass.incubator.internal.ftrace.core.binary.event.BinaryFTraceConstants.HEADER_EVENT_TYPE_LENGTH_VALUE_SEPARATOR;
 import static org.eclipse.tracecompass.incubator.internal.ftrace.core.binary.event.BinaryFTraceConstants.NEW_LINE;
 
-import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -79,7 +78,7 @@ public abstract class AbstractBinaryFTraceFileParser {
             BinaryFTraceVersion ftraceVersionEnum = BinaryFTraceVersion.getVersionAsEnum(ftraceVersionInt);
             return new BinaryFTraceVersionHeader(magicValues, ftraceVersionEnum);
         } catch (NumberFormatException e) {
-            throw new TmfTraceException("Cannot parse the magic values and FTrace version. Make sure you use trace-cmd v.2.9 and above.", e); //$NON-NLS-1$
+            throw new TmfTraceException("Cannot parse the magic values and FTrace version. Make sure you use trace-cmd v.2.9 and above. strVersion=" + strVersion, e); //$NON-NLS-1$
         }
     }
 
@@ -90,16 +89,13 @@ public abstract class AbstractBinaryFTraceFileParser {
      *            The buffer that is currently pointing to the endianess value
      *            of the trace file
      * @return The endianess of the file as a {@link ByteOrder} value
-     * @throws IOException
-     *             If an error occur while reading the file
      */
-    protected static ByteOrder getFileEndianess(BinaryFTraceByteBuffer buffer) throws IOException {
+    protected static ByteOrder getFileEndianess(BinaryFTraceByteBuffer buffer) {
         int endianess = buffer.getNextBytes(1)[0];
         ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
         if (endianess == 0) {
             byteOrder = ByteOrder.LITTLE_ENDIAN;
         }
-        buffer.setByteOrder(byteOrder);
 
         return byteOrder;
     }
@@ -113,15 +109,12 @@ public abstract class AbstractBinaryFTraceFileParser {
      * @return The long value size of the trace file (either 4 or 8)
      * @throws TmfTraceException
      *             If an error occur while validating the long value size
-     * @throws IOException
-     *             If an error occur while reading the long value size from the
-     *             trace
      */
-    protected static int getLongValueSize(BinaryFTraceByteBuffer buffer) throws TmfTraceException, IOException {
+    protected static int getLongValueSize(BinaryFTraceByteBuffer buffer) throws TmfTraceException {
         int longValueSize = buffer.getNextBytes(1)[0];
 
         if (longValueSize != 4 && longValueSize != 8) {
-            throw new TmfTraceException("Invalid size for long value, must be either 4 or 8 bytes"); //$NON-NLS-1$
+            throw new TmfTraceException("Invalid size for long value, must be either 4 or 8 bytes, got " + longValueSize); //$NON-NLS-1$
         }
 
         return longValueSize;
@@ -134,10 +127,8 @@ public abstract class AbstractBinaryFTraceFileParser {
      *            The buffer that is currently pointing to the host page size
      *            value in the trace file
      * @return The host page size value of the trace file
-     * @throws IOException
-     *             If an error occurred while reading the host page size value
      */
-    protected static int getHostPageSize(BinaryFTraceByteBuffer buffer) throws IOException {
+    protected static int getHostPageSize(BinaryFTraceByteBuffer buffer) {
         return buffer.getNextInt();
     }
 

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/parser/BinaryFTraceFileMapping.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/binary/parser/BinaryFTraceFileMapping.java
@@ -1,0 +1,140 @@
+package org.eclipse.tracecompass.incubator.internal.ftrace.core.binary.parser;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.ArrayList;
+
+/**
+ * Helper class to map a large file (> 2GB) using a list of MappedByteBuffers.
+ *
+ * Provides an interface (read only) similar to ByteBuffer, but uses a long
+ * index instead of int.
+ */
+public final class BinaryFTraceFileMapping {
+    /**
+     * Length of the file segment mapped by each buffer.
+     */
+    public static final long SEGMENT_LEN = ((long) 1) << 31;
+
+    /**
+     * Overlap of each segment into the next, to easily access data that
+     * sits at segment boundary.
+     */
+    public static final long SEGMENT_OVERLAP = 1 << 20; // 1MB overlap
+
+    private final long fLength;
+    private ArrayList<MappedByteBuffer> fMappedBuffers = new ArrayList<>();
+
+    /**
+     * Create a mapping for the given file.
+     *
+     * @param filePath the file path
+     * @throws IOException if the file can't be opened or mapped
+     */
+    public BinaryFTraceFileMapping(String filePath) throws IOException {
+        try (RandomAccessFile file = new RandomAccessFile(filePath, "r")) { //$NON-NLS-1$
+            @SuppressWarnings("resource")
+            FileChannel channel = file.getChannel(); // channel is closed automatically by the file
+            fLength = file.length();
+            final int segmentCount = (int)(fLength / SEGMENT_LEN);
+            fMappedBuffers.ensureCapacity(segmentCount + 1);
+            for (int i = 0; i < segmentCount; i++) {
+                fMappedBuffers.add(channel.map(MapMode.READ_ONLY, i * SEGMENT_LEN, SEGMENT_LEN + SEGMENT_OVERLAP));
+            }
+            long remaining = fLength - segmentCount * SEGMENT_LEN;
+            if (remaining > 0) {
+                fMappedBuffers.add(channel.map(MapMode.READ_ONLY, segmentCount * SEGMENT_LEN, remaining));
+            }
+        }
+    }
+
+    /**
+     * Set the byte order for the read operations.
+     *
+     * @param endianess the byte order to set
+     */
+    public void order(ByteOrder endianess) {
+        for (MappedByteBuffer buffer : fMappedBuffers) {
+            buffer.order(endianess);
+        }
+    }
+
+    /**
+     * Fill the given array with bytes from the file at the given position.
+     *
+     * @param index position to read from
+     * @param dst the byte array to fill
+     */
+    public void get(long index, byte[] dst) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        mappedBuffer.get((int)(index % SEGMENT_LEN), dst);
+    }
+
+    /**
+     * Read a single byte from the given position.
+     *
+     * @param index position to read from
+     * @return the value
+     */
+    public byte getByte(long index) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        return mappedBuffer.get((int)(index % SEGMENT_LEN));
+    }
+
+    /**
+     * Read an int (4 bytes) from the given position.
+     *
+     * @param index position to read from
+     * @return the value
+     */
+    public int getInt(long index) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        return mappedBuffer.getInt((int)(index % SEGMENT_LEN));
+    }
+
+    /**
+     * Read a double (8 bytes) from the given position.
+     *
+     * @param index position to read from
+     * @return the value
+     */
+    public double getDouble(long index) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        return mappedBuffer.getDouble((int)(index % SEGMENT_LEN));
+    }
+
+    /**
+     * Read a long (8 bytes) from the given position.
+     *
+     * @param index position to read from
+     * @return the value
+     */
+   public long getLong(long index) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        return mappedBuffer.getLong((int)(index % SEGMENT_LEN));
+    }
+
+   /**
+    * Read a short (2 bytes) from the given position.
+    *
+    * @param index position to read from
+    * @return the value
+    */
+    public short getShort(long index) {
+        MappedByteBuffer mappedBuffer = fMappedBuffers.get((int) (index / SEGMENT_LEN));
+        return mappedBuffer.getShort((int)(index % SEGMENT_LEN));
+    }
+
+    /**
+     * Get the mapped length (the file size).
+     *
+     * @return the mapped length (the file size)
+     */
+    public long length() {
+        return fLength;
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/strategies/BinaryFTraceV6Strategy.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/strategies/BinaryFTraceV6Strategy.java
@@ -141,4 +141,11 @@ public class BinaryFTraceV6Strategy implements IBinaryFTraceStrategy {
     public ITmfContext createIterator() throws IOException {
         return new BinaryFTraceIterator(fTraceHeaderData, fFTrace);
     }
+
+    @Override
+    public void dispose() {
+        // release (indirect) references to mem-mapped file buffers so that tracecompass
+        // can garbage-collect them and unlock the file (e.g. if the user wants to delete it)
+        fTraceHeaderData = null;
+    }
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/strategies/IBinaryFTraceStrategy.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/strategies/IBinaryFTraceStrategy.java
@@ -68,4 +68,11 @@ public interface IBinaryFTraceStrategy {
      *         provided by the parameter.
      */
     public ITmfContext seekEvent(ITmfLocation location);
+
+    /**
+     * Dispose of the strategy.
+     *
+     * Can be used to release system resources.
+     */
+    public void dispose();
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/trace/BinaryFTrace.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ftrace.core/src/org/eclipse/tracecompass/incubator/internal/ftrace/core/trace/BinaryFTrace.java
@@ -115,6 +115,14 @@ public class BinaryFTrace extends GenericFtrace implements ITmfPropertiesProvide
         setFile(file);
     }
 
+    @Override
+    public synchronized void dispose() {
+        super.dispose();
+        if (fStrategy != null) {
+            fStrategy.dispose();
+        }
+    }
+
     private static File initTraceAsText(File file) throws TmfTraceException {
         if (!file.exists()) {
             ProcessBuilder pb = new ProcessBuilder(TRACE_CMD, REPORT, "-i", file.getAbsolutePath(), "-R"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
* mmap the whole file for faster parsing
* re-use the same mapping to read events

on my (oldish) laptop with ubuntu 24.04 the file is parsed an order of magnitude faster

on a recent windows laptop I measured two orders of magnitude faster