### PR TITLE
releng: Downgrade org.mozilla.rhino to org.mozilla.javascript

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="76">
+<target name="tracecompass-incubator-master" sequenceNumber="77">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -77,11 +77,14 @@
 <unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.43.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.mozilla.rhino" version="1.7.15"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.32.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mozilla.javascript" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
@@ -131,10 +134,10 @@
 <unit id="org.eclipse.tracecompass.lttng2.control.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.jsontrace.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.cli.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tracecompass/releases/10.0.0/repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/10.0.1/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/tracecompass/releases/10.0.0/rcp-repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/10.0.1/rcp-repository/"/>
 <unit id="org.eclipse.tracecompass.rcp.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Use older version of org.mozilla.javascript for compatibility with incubator EASE Scripting feature.