### PR TITLE
server: Fix potential trace UUID mismatch when creating experiment model

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
@@ -12,23 +12,17 @@
 package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import org.eclipse.core.resources.IResource;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
-import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Experiment model for TSP
@@ -88,11 +82,8 @@ public final class Experiment implements Serializable {
      * @return the experiment model
      */
     public static Experiment from(TmfExperiment experiment, UUID expUUID) {
-        Iterator<UUID> iter = ExperimentManagerService.getTraceUUIDs(expUUID).iterator();
-        // Get all the leaf traces from experiment
-        @NonNull List<@NonNull ITmfTrace> children = new ArrayList<>(TmfTraceManager.getTraceSet(experiment));
-        Set<Trace> traces = Sets.newLinkedHashSet(Lists.transform(children,
-                t -> Trace.from(t, iter.next())));
+        List<UUID> traceUUIDs = ExperimentManagerService.getTraceUUIDs(expUUID);
+        Set<Trace> traces = new LinkedHashSet<>(Lists.transform(traceUUIDs, uuid -> Trace.from(TraceManagerService.getTraceResource(uuid), uuid)));
         return new Experiment(experiment.getName(),
                 expUUID,
                 experiment.getNbEvents(),


### PR DESCRIPTION
Don't rely on the order of traces array in experiment and trace UUIDs stored in ExperimentManagerService to create TSP Experiment model. Instead use the trace resources to create the TSP Trace model return in the TSP Experiment Model.

Fixes #51

[Fixed] potential trace UUID mismatch when creating experiment model