### PR TITLE
Remove UI dependencies in various core plug-ins

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.filters.core.tests/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.filters.core.tests/META-INF/MANIFEST.MF
@@ -20,5 +20,4 @@ Export-Package: org.eclipse.tracecompass.incubator.filters.core.tests,
  org.eclipse.tracecompass.incubator.filters.core.tests.server,
  org.eclipse.tracecompass.incubator.filters.core.tests.stubs
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.lsp.core.tests
-Import-Package: org.antlr.runtime,
- org.eclipse.tracecompass.incubator.internal.filters.ui.lspFilterTextbox
+Import-Package: org.antlr.runtime

--- a/tracetypes/org.eclipse.tracecompass.incubator.jifa.core/META-INF/MANIFEST.MF
+++ b/tracetypes/org.eclipse.tracecompass.incubator.jifa.core/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tracecompass.tmf.core,
  org.eclipse.tracecompass.analysis.counters.core,
  org.eclipse.tracecompass.tmf.analysis.xml.core,
- org.eclipse.tracecompass.tmf.ui,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
 Export-Package: org.eclipse.tracecompass.incubator.internal.jifa.core;x-friends:="org.eclipse.tracecompass.incubator.jifa.core.tests",
  org.eclipse.tracecompass.incubator.internal.jifa.core.gclog;x-friends:="org.eclipse.tracecompass.incubator.jifa.core.tests",

--- a/tracetypes/org.eclipse.tracecompass.incubator.perf.profiling.core/META-INF/MANIFEST.MF
+++ b/tracetypes/org.eclipse.tracecompass.incubator.perf.profiling.core/META-INF/MANIFEST.MF
@@ -24,6 +24,5 @@ Export-Package: org.eclipse.tracecompass.incubator.internal.perf.profiling.core;
  org.eclipse.tracecompass.incubator.internal.perf.profiling.core.callgraph;x-friends:="org.eclipse.tracecompass.incubator.perf.profiling.core.tests",
  org.eclipse.tracecompass.incubator.internal.perf.profiling.core.symbol;x-internal:=true,
  org.eclipse.tracecompass.incubator.internal.perf.profiling.core.trace;x-internal:=true
-Import-Package: com.google.common.collect,
- org.eclipse.tracecompass.internal.tmf.ui.symbols
+Import-Package: com.google.common.collect
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.perf.profiling.core

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros.core/META-INF/MANIFEST.MF
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros.core/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tracecompass.lttng2.ust.core,
  org.eclipse.tracecompass.tmf.ctf.core,
  org.eclipse.tracecompass.ctf.core,
- org.eclipse.tracecompass.tmf.ui,
  org.eclipse.tracecompass.statesystem.core,
  org.eclipse.tracecompass.analysis.os.linux.core,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/META-INF/MANIFEST.MF
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tracecompass.lttng2.ust.core,
  org.eclipse.tracecompass.tmf.ctf.core,
  org.eclipse.tracecompass.ctf.core,
- org.eclipse.tracecompass.tmf.ui,
  org.eclipse.tracecompass.analysis.os.linux.core,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
 Export-Package: org.eclipse.tracecompass.incubator.internal.ros2.core;x-friends:="org.eclipse.tracecompass.incubator.ros2.core.tests,org.eclipse.tracecompass.incubator.ros2.ui",


### PR DESCRIPTION
Core plug-ins should not have UI dependencies. 

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>