### PR TITLE
rocm: restore previous ROCm analysis

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.rocm.core/plugin.xml
+++ b/analyses/org.eclipse.tracecompass.incubator.rocm.core/plugin.xml
@@ -20,4 +20,16 @@
             trace_type="org.eclipse.tracecompass.incubator.rocm.core.ctfplugin.trace.RocmCtfPluginTrace">
       </type>
    </extension>
+   <extension
+         point="org.eclipse.linuxtools.tmf.core.analysis">
+      <module
+            analysis_module="org.eclipse.tracecompass.incubator.internal.rocm.core.analysis.RocmCallStackAnalysis"
+            id="org.eclipse.tracecompass.incubator.rocm.core.stateprovider.atomic"
+            name="ROCm Analysis">
+         <tracetype
+               applies="true"
+               class="org.eclipse.tracecompass.incubator.rocm.core.ctfplugin.trace.RocmCtfPluginTrace">
+         </tracetype>
+      </module>
+   </extension>
 </plugin>


### PR DESCRIPTION
This analysis was removed from the extensions as the trace type changed. It is needed again so this commit adds it again to the plugin extensions.