### PR TITLE
[server][readme] fix reference to general build instructions

### DIFF
--- a/trace-server/README.md
+++ b/trace-server/README.md
@@ -13,7 +13,7 @@
 
 ## Compiling manually
 
-To build the project manually follow the instructions in [BUILDING](#compiling-manually).
+To build the project manually follow the instructions in [BUILDING](../BUILDING).
 
 The resulting trace server executables will be in the
 `trace-server/org.eclipse.tracecompass.incubator.trace.server.product/target/products`.


### PR DESCRIPTION
Currently the reference points to itself - it seems to make more sense to point to the root BUILDING.md file.