### PR TITLE
Add missing features to legacy rcp product definition

### DIFF
--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy/tracing.incubator.product
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy/tracing.incubator.product
@@ -159,6 +159,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.tracecompass"/>
       <feature id="org.eclipse.tracecompass.incubator.traceevent"/>
       <feature id="org.eclipse.tracecompass.incubator.uftrace"/>
+      <feature id="org.eclipse.tracecompass.incubator.gpu"/>
       <feature id="org.eclipse.tracecompass.incubator.tmf.ui.multiview"/>
       <feature id="org.eclipse.ecf.filetransfer.httpclient45.feature"/>
       <feature id="org.eclipse.tracecompass.jsontrace" installMode="root"/>

--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy/tracing.incubator.product
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy/tracing.incubator.product
@@ -146,6 +146,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.atrace"/>
       <feature id="org.eclipse.tracecompass.incubator.callstack"/>
       <feature id="org.eclipse.tracecompass.incubator.eventfieldcount"/>
+      <feature id="org.eclipse.tracecompass.incubator.executioncomparison"/>
       <feature id="org.eclipse.tracecompass.incubator.ftrace"/>
       <feature id="org.eclipse.tracecompass.incubator.hudson.maven"/>
       <feature id="org.eclipse.tracecompass.incubator.inandout"/>


### PR DESCRIPTION
`org.eclipse.tracecompass.incubator.gpu` and `org.eclipse.tracecompass.incubator.executioncomparision` feature were missing and this PR adds these features to the legacy RCP product definition. Even if the legacy product definition is only used in branch 2021-06, it needs to be consistent in master branch as well. This will future cherry-picks to 2021-06 branch easier.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>