### PR TITLE
server: support for customizable data providers (outputs) via data provider factories

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
@@ -366,7 +366,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
             parameters.put(PATH, path);
         }
         return endpoint.request(MediaType.APPLICATION_JSON)
-                .post(Entity.json(new ConfigurationQueryParameters(parameters)));
+                .post(Entity.json(new ConfigurationQueryParameters(null, null, null, parameters)));
     }
 
     private static Response createJsonConfig(String jsonFileName) throws URISyntaxException, IOException {
@@ -384,7 +384,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
                 ObjectMapper mapper = new ObjectMapper();
                 Map<String, Object> params = mapper.readValue(inputStream, new TypeReference<Map<String, Object>>() {});
                 return endpoint.request(MediaType.APPLICATION_JSON)
-                        .post(Entity.json(new ConfigurationQueryParameters(params)));
+                        .post(Entity.json(new ConfigurationQueryParameters(null, null, null, params)));
             }
     }
 
@@ -417,7 +417,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
             parameters.put(PATH, path);
         }
         return endpoint.request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(new ConfigurationQueryParameters(parameters)));
+                .put(Entity.json(new ConfigurationQueryParameters(null, null, null, parameters)));
     }
 
     private static Response deleteConfig(String id) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/ConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/ConfigurationQueryParameters.java
@@ -15,44 +15,81 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
-
-import io.swagger.v3.oas.annotations.Hidden;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 
 /**
  * Definition of a parameters object received by the server from a client for configurations.
  */
 public class ConfigurationQueryParameters {
+    private @NonNull String name;
+    private @NonNull String description;
+    private @NonNull String typeId;
     private @NonNull Map<String, Object> parameters;
 
     /**
      * Constructor for Jackson
      */
     public ConfigurationQueryParameters() {
+
         // Default constructor for Jackson
         this.parameters = new HashMap<>();
+        this.name = TmfConfiguration.UNKNOWN;
+        this.description = TmfConfiguration.UNKNOWN;
+        this.typeId = TmfConfiguration.UNKNOWN;
     }
 
     /**
      * Constructor.
      *
+     * @param name
+     *            the name of the configuration
+     * @param description
+     *            the description of the configuration
+     * @param typeId
+     *            the typeId of the configuration
+     *
      * @param parameters
      *            Map of parameters
      */
-    public ConfigurationQueryParameters(Map<String, Object> parameters) {
+    public ConfigurationQueryParameters(String name, String description, String typeId, Map<String, Object> parameters) {
         this.parameters = parameters != null ? parameters : new HashMap<>();
+        this.name = name == null ? TmfConfiguration.UNKNOWN : name;
+        this.description = description == null ? TmfConfiguration.UNKNOWN : description;
+        this.typeId = typeId == null ? TmfConfiguration.UNKNOWN : typeId;
     }
 
     /**
-     * @return Map of parameters
+     * @return the name of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
      */
-    @Hidden
-    public @NonNull Map<String, Object> getParameters() {
+    @NonNull public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the description of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
+     */
+    @NonNull public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return the type ID of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
+     */
+    @NonNull  public String getTypeId() {
+        return typeId;
+    }
+
+    /**
+     * @return Map of parameters or empty map if not provided
+     */
+    @NonNull public Map<String, Object> getParameters() {
         return parameters;
     }
 
     @SuppressWarnings("nls")
     @Override
     public String toString() {
-        return "ConfigurationQueryParameters [parameters=" + parameters + "]";
+        return "ConfigurationQueryParameters [name=" + getName() + ", description=" + getDescription()
+           +", typeId=" + getTypeId() + "parameters=" + getParameters() + "]";
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ConfigurationManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ConfigurationManagerService.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response.Status;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.ConfigurationQueryParameters;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSource;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfigurationSourceManager;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
 
@@ -151,9 +152,14 @@ public class ConfigurationManagerService {
         if (queryParameters == null) {
             return Response.status(Status.BAD_REQUEST).entity(EndpointConstants.MISSING_PARAMETERS).build();
         }
-
+        ITmfConfiguration inputConfig = new TmfConfiguration.Builder()
+                    .setName(queryParameters.getName())
+                    .setDescription(queryParameters.getDescription())
+                    .setSourceTypeId(typeId)
+                    .setParameters(queryParameters.getParameters())
+                    .build();
         try {
-            ITmfConfiguration config = configurationSource.create(queryParameters.getParameters());
+            ITmfConfiguration config = configurationSource.create(inputConfig);
             return Response.ok(config).build();
         } catch (TmfConfigurationException e) {
             return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
@@ -232,8 +238,15 @@ public class ConfigurationManagerService {
             return Response.status(Status.NOT_FOUND).entity("Configuration instance doesn't exist for type " + typeId).build(); //$NON-NLS-1$
         }
 
+        ITmfConfiguration inputConfig = new TmfConfiguration.Builder()
+                .setId(configId)
+                .setName(queryParameters.getName())
+                .setDescription(queryParameters.getDescription())
+                .setSourceTypeId(typeId)
+                .setParameters(queryParameters.getParameters())
+                .build();
         try {
-            ITmfConfiguration config = configurationSource.update(configId, queryParameters.getParameters());
+            ITmfConfiguration config = configurationSource.update(configId, inputConfig);
             return Response.ok(config).build();
         } catch (TmfConfigurationException e) {
             return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -34,11 +34,23 @@ public final class EndpointConstants {
     /** Error message returned for a request with missing parameters */
     public static final String MISSING_PARAMETERS = "Missing query parameters"; //$NON-NLS-1$
 
+    /** Error message returned for a request with configuration type ID */
+    public static final String MISSING_TYPE_ID = "Missing configuration type ID"; //$NON-NLS-1$
+
     /** Error message returned for a request with invalid parameters */
     public static final String INVALID_PARAMETERS = "Invalid query parameters"; //$NON-NLS-1$
 
     /** Error message returned for a request for a non-existing data provider */
     public static final String NO_PROVIDER = "Analysis cannot run"; //$NON-NLS-1$
+
+    /** Error message returned for a request for trace that doesn't exist */
+    public static final String NO_SUCH_CONFIGURATION_TYPE = "No such configuration type"; //$NON-NLS-1$
+
+    /** Error message returned for a request for a non-existing derived data provider */
+    public static final String NO_SUCH_DERIVED_PROVIDER = "Derived data provider doesn't exist"; //$NON-NLS-1$
+
+    /** Error message returned for a request for a non-existing data provider */
+    public static final String NO_SUCH_PROVIDER = "Data provider doesn't exist"; //$NON-NLS-1$
 
     /** Error message returned for a request for trace that doesn't exist */
     public static final String NO_SUCH_TRACE = "No such trace"; //$NON-NLS-1$
@@ -166,6 +178,7 @@ public final class EndpointConstants {
     static final String TRACE_CREATION_FAILED = "Trace resource creation failed"; //$NON-NLS-1$
     static final String TREE_ENTRIES = "Unique entry point for output providers, to get the tree of visible entries"; //$NON-NLS-1$
     static final String NO_SUCH_CONFIGURATION = "No such configuration source type or configuration instance"; //$NON-NLS-1$
+    static final String PROVIDER_CONFIG_NOT_FOUND = "Experiment, output provider or configuration type not found"; //$NON-NLS-1$
 
     private EndpointConstants() {
         // private constructor


### PR DESCRIPTION
It uses the new `IDataProviderFactory.getAdapter()` interface to get `ITmfDataProviderConfigurator` implementation to create data providers. It passes an `ITmfConfiguration` instance with default TSP parameters (name, description, typeId) and the custom parameters in a JSON converted `Map<String, Object>` on to the configurator which the implementer of `ITmfDataProviderConfigurator` needs to apply.

It depends on 
https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/154
https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/167

~~This PR includes changes of PR #71 and its dependent pull requests, and will be rebased once dependent PRs are merged.~~