### PR TITLE
[server] Add trace properties to the Trace instance

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TraceModelStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TraceModelStub.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Ericsson
+ * Copyright (c) 2018, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -12,6 +12,7 @@
 package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
 
 import java.nio.charset.Charset;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -37,6 +38,7 @@ public class TraceModelStub extends AbstractModelStub {
     private static final long serialVersionUID = -1030854786688167776L;
 
     private final String fPath;
+    private final Map<String, String> fProperties;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -53,6 +55,8 @@ public class TraceModelStub extends AbstractModelStub {
      *            start time
      * @param end
      *            end time
+     * @param properties
+     *            the properties of the trace
      * @param indexingStatus
      *            indexing status
      */
@@ -64,9 +68,11 @@ public class TraceModelStub extends AbstractModelStub {
             @JsonProperty("nbEvents") long nbEvents,
             @JsonProperty("start") long start,
             @JsonProperty("end") long end,
+            @JsonProperty("properties") Map<String, String> properties,
             @JsonProperty("indexingStatus") String indexingStatus) {
         super(name, uuid, nbEvents, start, end, indexingStatus);
         fPath = path;
+        fProperties = properties;
     }
 
     /**
@@ -76,9 +82,11 @@ public class TraceModelStub extends AbstractModelStub {
      *            trace name
      * @param path
      *            path to trace on server file system
+     * @param properties
+     *            properties of the trace
      */
-    public TraceModelStub(String name, String path) {
-        this(name, path, getUUID(path, name), 0, 0L, 0L, "RUNNING");
+    public TraceModelStub(String name, String path, Map<String, String> properties) {
+        this(name, path, getUUID(path, name), 0, 0L, 0L, properties, "RUNNING");
     }
 
     private static UUID getUUID(String path, String name) {
@@ -93,6 +101,14 @@ public class TraceModelStub extends AbstractModelStub {
      */
     public String getPath() {
         return fPath;
+    }
+
+    /**
+     * Returns the trace's properties
+     * @return the trace's properties
+     */
+    public Map<String, String> getProperties() {
+        return fProperties;
     }
 
     @Override
@@ -111,7 +127,7 @@ public class TraceModelStub extends AbstractModelStub {
             return false;
         } else if (obj instanceof TraceModelStub) {
             TraceModelStub other = (TraceModelStub) obj;
-            return Objects.equals(fPath, other.fPath);
+            return Objects.equals(fPath, other.fPath) && Objects.equals(fProperties, other.fProperties);
         }
         return false;
     }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Ericsson
+ * Copyright (c) 2018, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -163,6 +163,19 @@ public abstract class RestServerTest {
     protected static final String CONTEXT_SWITCHES_UST_NAME = "ust";
 
     /**
+     * The properties of the trace.
+     */
+    public static final Map<String, String> CONTEXT_SWITCHES_UST_PROPERTIES = new HashMap<>(Map.ofEntries(
+            Map.entry("hostname", "\"qemu1\""),
+            Map.entry("clock_offset", "1450192743562703624"),
+            Map.entry("domain", "\"ust\""),
+            Map.entry("host ID", "\"40b6dd3a-c130-431e-92ef-8c4dafe14627\""),
+            Map.entry("tracer_name", "\"lttng-ust\""),
+            Map.entry("tracer_major", "2"),
+            Map.entry("tracer_minor", "6")
+        ));
+
+    /**
      * {@link TraceModelStub} to represent the object returned by the server for
      * {@link CtfTestTrace#CONTEXT_SWITCHES_KERNEL}.
      */
@@ -174,6 +187,23 @@ public abstract class RestServerTest {
     protected static final String CONTEXT_SWITCHES_KERNEL_NAME = "kernel";
 
     /**
+     * The properties of the trace.
+     */
+    public static final Map<String, String> CONTEXT_SWITCHES_KERNEL_PROPERTIES = new HashMap<>(Map.ofEntries(
+            Map.entry("hostname", "\"qemu1\""),
+            Map.entry("kernel_version", "\"#1 SMP PREEMPT Sat Dec 12 14:52:43 CET 2015\""),
+            Map.entry("tracer_patchlevel", "3"),
+            Map.entry("clock_offset", "1450192747804379176"),
+            Map.entry("domain", "\"kernel\""),
+            Map.entry("sysname", "\"Linux\""),
+            Map.entry("host ID", "\"40b6dd3a-c130-431e-92ef-8c4dafe14627\""),
+            Map.entry("kernel_release", "\"4.1.13-WR8.0.0.0_standard\""),
+            Map.entry("tracer_name", "\"lttng-modules\""),
+            Map.entry("tracer_major", "2"),
+            Map.entry("tracer_minor", "6")
+        ));
+
+    /**
      * {@link TraceModelStub} to represent the object returned by the server for
      * {@link CtfTestTrace#ARM_64_BIT_HEADER}, with the same name as {@link #CONTEXT_SWITCHES_KERNEL_STUB}
      */
@@ -183,6 +213,23 @@ public abstract class RestServerTest {
      * The name used when posting the trace.
      */
     protected static final String ARM_64_KERNEL_NAME = "kernel";
+
+    /**
+     * The properties of the trace.
+     */
+    public static final Map<String, String> ARM_64_KERNEL_PROPERTIES = new HashMap<>(Map.ofEntries(
+            Map.entry("hostname", "\"lager\""),
+            Map.entry("kernel_version", "\"#6 SMP PREEMPT Wed Oct 1 17:07:11 CEST 2014\""),
+            Map.entry("tracer_patchlevel", "0"),
+            Map.entry("clock_offset", "1412663327522716450"),
+            Map.entry("domain", "\"kernel\""),
+            Map.entry("sysname", "\"Linux\""),
+            Map.entry("host ID", "\"5a71a43c-1390-4365-9baf-111c565e78c3\""),
+            Map.entry("kernel_release", "\"3.10.31-ltsi\""),
+            Map.entry("tracer_name", "\"lttng-modules\""),
+            Map.entry("tracer_major", "2"),
+            Map.entry("tracer_minor", "5")
+        ));
 
     /**
      * Expected toString() of all data providers for this experiment
@@ -198,13 +245,13 @@ public abstract class RestServerTest {
     @BeforeClass
     public static void beforeTest() throws IOException {
         String contextSwitchesUstPath = FileLocator.toFileURL(CtfTestTrace.CONTEXT_SWITCHES_UST.getTraceURL()).getPath().replaceAll("/$", "");
-        CONTEXT_SWITCHES_UST_STUB = new TraceModelStub(CONTEXT_SWITCHES_UST_NAME, contextSwitchesUstPath);
+        CONTEXT_SWITCHES_UST_STUB = new TraceModelStub(CONTEXT_SWITCHES_UST_NAME, contextSwitchesUstPath, CONTEXT_SWITCHES_UST_PROPERTIES);
 
         String contextSwitchesKernelPath = FileLocator.toFileURL(CtfTestTrace.CONTEXT_SWITCHES_KERNEL.getTraceURL()).getPath().replaceAll("/$", "");
-        CONTEXT_SWITCHES_KERNEL_STUB = new TraceModelStub(CONTEXT_SWITCHES_KERNEL_NAME, contextSwitchesKernelPath);
+        CONTEXT_SWITCHES_KERNEL_STUB = new TraceModelStub(CONTEXT_SWITCHES_KERNEL_NAME, contextSwitchesKernelPath, CONTEXT_SWITCHES_KERNEL_PROPERTIES);
 
         String arm64Path = FileLocator.toFileURL(CtfTestTrace.ARM_64_BIT_HEADER.getTraceURL()).getPath().replaceAll("/$", "");
-        ARM_64_KERNEL_STUB = new TraceModelStub(ARM_64_KERNEL_NAME, arm64Path);
+        ARM_64_KERNEL_STUB = new TraceModelStub(ARM_64_KERNEL_NAME, arm64Path, ARM_64_KERNEL_PROPERTIES);
 
         ImmutableList.Builder<DataProviderDescriptorStub> b = ImmutableList.builder();
         b.add(new DataProviderDescriptorStub("org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.scatter.dataprovider:org.eclipse.linuxtools.lttng2.ust.analysis.callstack",

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Trace.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Trace.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Ericsson
+ * Copyright (c) 2021, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -11,6 +11,7 @@
 
 package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
 
+import java.util.Map;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,6 +59,12 @@ public interface Trace {
      */
     @Schema(description = "The trace's end time")
     long getEnd();
+
+    /**
+     * @return The properties.
+     */
+    @Schema(description = "The trace's properties")
+    Map<String, String> getProperties();
 
     /**
      * @return The indexing status.

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Ericsson
+ * Copyright (c) 2020, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -83,7 +83,7 @@ public final class Experiment implements Serializable {
      */
     public static Experiment from(TmfExperiment experiment, UUID expUUID) {
         List<UUID> traceUUIDs = ExperimentManagerService.getTraceUUIDs(expUUID);
-        Set<Trace> traces = new LinkedHashSet<>(Lists.transform(traceUUIDs, uuid -> Trace.from(TraceManagerService.getTraceResource(uuid), uuid)));
+        Set<Trace> traces = new LinkedHashSet<>(Lists.transform(traceUUIDs, uuid -> Trace.from(TraceManagerService.getOrCreateTraceInstance(uuid), uuid)));
         return new Experiment(experiment.getName(),
                 expUUID,
                 experiment.getNbEvents(),

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ExperimentManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ExperimentManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Ericsson
+ * Copyright (c) 2018, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -210,8 +210,8 @@ public class ExperimentManagerService {
         if (resource == null) {
             return Response.status(Status.NOT_FOUND).build();
         }
-        Experiment experimentModel = Experiment.from(resource, expUUID);
         TmfExperiment experiment = EXPERIMENTS.remove(expUUID);
+        Experiment experimentModel = experiment != null ? Experiment.from(experiment, expUUID) : Experiment.from(resource, expUUID);
         if (experiment != null) {
             TmfSignalManager.dispatchSignal(new TmfTraceClosedSignal(this, experiment));
             experiment.dispose();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Trace.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Trace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Ericsson
+ * Copyright (c) 2020, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -12,11 +12,14 @@
 package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.tracecompass.tmf.core.io.ResourceUtil;
+import org.eclipse.tracecompass.tmf.core.project.model.ITmfPropertiesProvider;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -33,6 +36,7 @@ public final class Trace implements Serializable {
     private final long fNbEvents;
     private final long fStart;
     private final long fEnd;
+    private final Map<String, String> fProperties;
     private final String fIndexingStatus;
 
     /**
@@ -50,6 +54,8 @@ public final class Trace implements Serializable {
      *            start time
      * @param end
      *            end time
+     * @param properties
+     *            the properties of the trace
      * @param indexingStatus
      *            indexing status
      */
@@ -60,6 +66,7 @@ public final class Trace implements Serializable {
             @JsonProperty("nbEvents") long nbEvents,
             @JsonProperty("start") long start,
             @JsonProperty("end") long end,
+            @JsonProperty("properties") Map<String, String> properties,
             @JsonProperty("indexingStatus") String indexingStatus) {
         fName = name;
         fUUID = uuid;
@@ -67,6 +74,7 @@ public final class Trace implements Serializable {
         fNbEvents = nbEvents;
         fStart = start;
         fEnd = end;
+        fProperties = properties;
         fIndexingStatus = indexingStatus;
     }
 
@@ -86,6 +94,7 @@ public final class Trace implements Serializable {
                 trace.getNbEvents(),
                 trace.getStartTime().toNanos(),
                 trace.getEndTime().toNanos(),
+                trace instanceof ITmfPropertiesProvider ? ((ITmfPropertiesProvider) trace).getProperties() : new HashMap<>(),
                 trace.isIndexing() ? "RUNNING" : "COMPLETED"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
@@ -110,6 +119,7 @@ public final class Trace implements Serializable {
                 0L,
                 0L,
                 0L,
+                new HashMap<>(),
                 "CLOSED"); //$NON-NLS-1$
     }
 
@@ -162,6 +172,14 @@ public final class Trace implements Serializable {
     }
 
     /**
+     * Returns the properties
+     * @return the properties
+     */
+    public Map<String, String> getProperties() {
+        return fProperties;
+    }
+
+    /**
      * Returns the indexing status
      * @return the indexing status
      */
@@ -171,6 +189,6 @@ public final class Trace implements Serializable {
 
     @Override
     public String toString() {
-        return "Trace [fName=" + fName + ", fUUID=" + fUUID + ", fPath=" + fPath + ", fNbEvents=" + fNbEvents + ", fStart=" + fStart + ", fEnd=" + fEnd + ", fIndexingStatus=" + fIndexingStatus + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$
+        return "Trace [fName=" + fName + ", fUUID=" + fUUID + ", fPath=" + fPath + ", fNbEvents=" + fNbEvents + ", fStart=" + fStart + ", fEnd=" + fEnd + ", fIndexingStatus=" + fIndexingStatus + ", fProperties" + fProperties.toString() + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TraceSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TraceSerializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Ericsson
+ * Copyright (c) 2018, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -12,6 +12,7 @@
 package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp;
 
 import java.io.IOException;
+import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.Trace;
@@ -48,6 +49,11 @@ public class TraceSerializer extends StdSerializer<@NonNull Trace> {
         gen.writeNumberField("nbEvents", value.getNbEvents()); //$NON-NLS-1$
         gen.writeNumberField("start", value.getStart()); //$NON-NLS-1$
         gen.writeNumberField("end", value.getEnd()); //$NON-NLS-1$
+        gen.writeObjectFieldStart("properties"); //$NON-NLS-1$
+        for (Entry<String, String> entry : value.getProperties().entrySet()) {
+            gen.writeStringField(entry.getKey(), entry.getValue());
+        }
+        gen.writeEndObject();
         gen.writeStringField("indexingStatus", value.getIndexingStatus()); //$NON-NLS-1$
         gen.writeEndObject();
     }


### PR DESCRIPTION
Cherry-pick from 2021-06 branch. See PR #79 for review.

----
The purpose of this commit is to get the trace properties using tsp. The "properties" attribute will be in the trace instance, and it will be filled if the opened trace implements ITmfPropertiesProviders.

Example:
{
  "name": "string",
  "path": "string",
  "nbEvents": 0,
  "start": 0,
  "indexingStatus": "RUNNING",
  "end": 0,
  "properties":
  {
	"hostname": "qemu1",
        "clock_offset": "1450192743562703624"
  },
  "UUID": "f50af7e0-0dd5-4361-ab96-2e04f7bc7e30"
}

[Added] "properties" field in the returned Trace instance [Added] a separate trace instrance will be created when "/traces" is queried [Changed] /experiment endpoint will use Trace.from(ITmfTrace) to get more info of the trace