### PR TITLE
server: Return table column data type

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TableColumnHeader.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TableColumnHeader.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 
 /**
@@ -27,7 +28,7 @@ public class TableColumnHeader {
     private final long fId;
     private final String fName;
     private final @Nullable String fDescription;
-    private final @Nullable String fType;
+    private final DataType fType;
 
     /**
      * Constructor
@@ -40,7 +41,7 @@ public class TableColumnHeader {
         List<@NonNull String> labels = dataModel.getLabels();
         fName = dataModel.getLabels().get(0);
         fDescription = labels.size() >= 2 ? dataModel.getLabels().get(1) : null;
-        fType = null;
+        fType = dataModel.getDataType();
     }
 
     /**
@@ -75,7 +76,7 @@ public class TableColumnHeader {
      *
      * @return The type of the column
      */
-    public String getType() {
+    public DataType getType() {
         return fType;
     }
 

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TreeModelWrapper.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TreeModelWrapper.java
@@ -14,7 +14,6 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
 import org.eclipse.tracecompass.tmf.core.model.ITableColumnDescriptor;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
@@ -40,7 +39,7 @@ public class TreeModelWrapper {
     public static class TreeColumnHeader {
         private final String fName;
         private final String fTooltip;
-        private final @Nullable String fDataType;
+        private final DataType fDataType;
 
         /**
          * Constructor with only the name
@@ -55,12 +54,7 @@ public class TreeModelWrapper {
         public TreeColumnHeader(String name, String tooltip, DataType dataType) {
             fName = name;
             fTooltip = tooltip;
-            if (dataType.equals(DataType.STRING)) {
-                // Default case
-                fDataType = null;
-            } else {
-                fDataType = dataType.name();
-            }
+            fDataType = dataType;
         }
 
         /**
@@ -85,7 +79,7 @@ public class TreeModelWrapper {
          *
          * @return data type.
          */
-        public @Nullable String getDataType() {
+        public DataType getDataType() {
             return fDataType;
         }
     }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TreeColumnHeaderSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TreeColumnHeaderSerializer.java
@@ -45,7 +45,7 @@ public class TreeColumnHeaderSerializer extends StdSerializer<@NonNull TreeColum
         gen.writeStringField("name", value.getName()); //$NON-NLS-1$
         gen.writeStringField("tooltip", value.getTooltip()); //$NON-NLS-1$
         if (value.getDataType() != null) {
-            gen.writeStringField("dataType", value.getDataType()); //$NON-NLS-1$
+            gen.writeStringField("dataType", value.getDataType().name()); //$NON-NLS-1$
         }
         gen.writeEndObject();
     }


### PR DESCRIPTION
Cherry-pick from master branch #84:

When requesting the table columns, the server will now return the type of each column. The types are derived from DataType enum, such as STRING, NUMBER, TIMESTAMP, DURATION, etc.

[Added] Accessing data type of table columns (i.e., headers)
