### PR TITLE
server: Fix tests failing due to new trace properties added in TC

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -171,6 +171,7 @@ public abstract class RestServerTest {
             Map.entry("domain", "\"ust\""),
             Map.entry("host ID", "\"40b6dd3a-c130-431e-92ef-8c4dafe14627\""),
             Map.entry("tracer_name", "\"lttng-ust\""),
+            Map.entry("clock_scale", "1.0"),
             Map.entry("tracer_major", "2"),
             Map.entry("tracer_minor", "6")
         ));
@@ -199,6 +200,7 @@ public abstract class RestServerTest {
             Map.entry("host ID", "\"40b6dd3a-c130-431e-92ef-8c4dafe14627\""),
             Map.entry("kernel_release", "\"4.1.13-WR8.0.0.0_standard\""),
             Map.entry("tracer_name", "\"lttng-modules\""),
+            Map.entry("clock_scale", "1.0"),
             Map.entry("tracer_major", "2"),
             Map.entry("tracer_minor", "6")
         ));
@@ -226,6 +228,7 @@ public abstract class RestServerTest {
             Map.entry("sysname", "\"Linux\""),
             Map.entry("host ID", "\"5a71a43c-1390-4365-9baf-111c565e78c3\""),
             Map.entry("kernel_release", "\"3.10.31-ltsi\""),
+            Map.entry("clock_scale", "1.0"),
             Map.entry("tracer_name", "\"lttng-modules\""),
             Map.entry("tracer_major", "2"),
             Map.entry("tracer_minor", "5")


### PR DESCRIPTION
The Trace Compass mainline PR below added a new trace properties to which has to be accounted for in the REST server tests:

https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/155

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>