### PR TITLE
server: fix NPE when fetch a trace by UUID and it's not available

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TraceManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TraceManagerServiceTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Collections;
 
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.core.resources.IFolder;
@@ -64,12 +65,17 @@ public class TraceManagerServiceTest extends RestServerTest {
         assertEquals("Expected set of traces to contain trace2 stub",
                 Collections.singleton(CONTEXT_SWITCHES_KERNEL_STUB), getTraces(traces));
 
-        Response deleteResponse = traces.path(kernelStub.getUUID().toString()).request().delete();
-        int deleteCode = deleteResponse.getStatus();
-        assertEquals("Failed to DELETE trace2, error code=" + deleteCode, 200, deleteCode);
-        assertEquals(CONTEXT_SWITCHES_KERNEL_STUB, deleteResponse.readEntity(TraceModelStub.class));
+        String kernelStubUUUID = kernelStub.getUUID().toString();
 
-        assertEquals("Trace should have been deleted", Collections.emptySet(), getTraces(traces));
+        try (Response deleteResponse = traces.path(kernelStubUUUID).request().delete()) {
+            int deleteCode = deleteResponse.getStatus();
+            assertEquals("Failed to DELETE trace2, error code=" + deleteCode, 200, deleteCode);
+            assertEquals(CONTEXT_SWITCHES_KERNEL_STUB, deleteResponse.readEntity(TraceModelStub.class));
+        }
+        try (Response response = traces.path(kernelStubUUUID).request(MediaType.APPLICATION_JSON).get()) {
+            assertEquals("Trace should have been deleted", 404, response.getStatus());
+        }
+        assertEquals("Trace should have been deleted and trace set should be empty", Collections.emptySet(), getTraces(traces));
     }
 
     /**

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
@@ -260,7 +260,9 @@ public class TraceManagerService {
             return TRACE_INSTANCES.get(uuid);
         }
         ITmfTrace trace = createTraceInstance(uuid);
-        TRACE_INSTANCES.put(uuid, trace);
+        if (trace != null) {
+            TRACE_INSTANCES.put(uuid, trace);
+        }
         return trace;
     }
 
@@ -300,8 +302,11 @@ public class TraceManagerService {
         }
     }
 
-    private static Trace createTraceModel(UUID uuid) {
+    private static @Nullable Trace createTraceModel(UUID uuid) {
         ITmfTrace trace = getOrCreateTraceInstance(uuid);
+        if (trace == null) {
+            return null;
+        }
         return Trace.from(trace, uuid);
     }
 


### PR DESCRIPTION
Fixes regression introduced by pull request:
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/79

[Fixed] NPE when fetch a trace by UUID and it's not available

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>