### PR TITLE
[server] Stop creating a separate trace instance when posting a trace

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Ericsson
+ * Copyright (c) 2023, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -256,7 +256,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
             TmfConfigurationStub config = response.readEntity(CONFIGURATION);
             validateConfig(config);
         }
-        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_KERNEL_STUB.getName(), CONTEXT_SWITCHES_KERNEL_STUB);
+        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
         WebTarget xmlProviderPath = getXYTreeEndpoint(exp.getUUID().toString(), "org.eclipse.linuxtools.tmf.analysis.xml.core.tests.xy");
         Map<String, Object> parameters = new HashMap<>();
         try (Response xmlTree = xmlProviderPath.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Ericsson and others
+ * Copyright (c) 2018, 2024 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -125,7 +125,7 @@ public class DataProviderServiceTest extends RestServerTest {
      */
     @Test
     public void testProviders() {
-        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_STUB.getName(), CONTEXT_SWITCHES_UST_STUB);
+        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
         WebTarget experiments = getApplicationEndpoint().path(EXPERIMENTS);
         WebTarget providers = experiments.path(exp.getUUID().toString())
@@ -142,7 +142,7 @@ public class DataProviderServiceTest extends RestServerTest {
      */
     @Test
     public void testCallStackDataProvider() {
-        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_STUB.getName(), CONTEXT_SWITCHES_UST_STUB);
+        ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
         WebTarget callstackTree = getTimeGraphTreeEndpoint(exp.getUUID().toString(), CALL_STACK_DATAPROVIDER_ID);
 
@@ -168,7 +168,7 @@ public class DataProviderServiceTest extends RestServerTest {
         long start = 1412670961211260539L;
         long end = 1412670967217750839L;
         try {
-            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_STUB.getName(), ARM_64_KERNEL_STUB);
+            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_NOT_INITIALIZED_STUB.getName(), ARM_64_KERNEL_NOT_INITIALIZED_STUB);
 
             // Test getting the tree endpoint for an XY chart
             WebTarget xyTree = getXYTreeEndpoint(exp.getUUID().toString(), XY_DATAPROVIDER_ID);
@@ -250,7 +250,7 @@ public class DataProviderServiceTest extends RestServerTest {
         long start = 1412670961211260539L;
         long end = 1412670967217750839L;
         try {
-            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_STUB.getName(), ARM_64_KERNEL_STUB);
+            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_NOT_INITIALIZED_STUB.getName(), ARM_64_KERNEL_NOT_INITIALIZED_STUB);
 
             // Test getting the tree endpoint for an XY chart
             WebTarget xyTree = getXYTreeEndpoint(exp.getUUID().toString(), XY_HISTOGRAM_DATAPROVIDER_ID);
@@ -312,7 +312,7 @@ public class DataProviderServiceTest extends RestServerTest {
         long start = 1450193697034689597L;
         long end = 1450193745774189602L;
         try {
-            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_STUB.getName(), CONTEXT_SWITCHES_UST_STUB);
+            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
             // Test getting the time graph tree
             WebTarget dataTree = getDataTreeEndpoint(exp.getUUID().toString(), STATISTICS_DATAPROVIDER_ID);
@@ -363,7 +363,7 @@ public class DataProviderServiceTest extends RestServerTest {
         long start = 1450193697034689597L;
         long end = 1450193745774189602L;
         try {
-            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_STUB.getName(), CONTEXT_SWITCHES_UST_STUB);
+            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
             // Test getting the time graph tree
             WebTarget callstackTree = getTimeGraphTreeEndpoint(exp.getUUID().toString(), CALL_STACK_DATAPROVIDER_ID);
@@ -534,7 +534,7 @@ public class DataProviderServiceTest extends RestServerTest {
         long start = 1412670961211260539L;
         long end = 1412670967217750839L;
         try {
-            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_STUB.getName(), ARM_64_KERNEL_STUB);
+            ExperimentModelStub exp = assertPostExperiment(ARM_64_KERNEL_NOT_INITIALIZED_STUB.getName(), ARM_64_KERNEL_NOT_INITIALIZED_STUB);
 
             // Test getting the tree endpoint for an XY chart
             WebTarget tableColumns = getTableColumnsEndpoint(exp.getUUID().toString(), EVENTS_TABLE_DATAPROVIDER_ID);
@@ -606,7 +606,7 @@ public class DataProviderServiceTest extends RestServerTest {
         @SuppressWarnings("resource")
         Response treeResponse = null;
         try {
-            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_STUB.getName(), CONTEXT_SWITCHES_UST_STUB);
+            ExperimentModelStub exp = assertPostExperiment(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB.getName(), CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
             // Test getting the time graph tree
             WebTarget callstackTree = getTimeGraphTreeEndpoint(exp.getUUID().toString(), TestDataProviderService.INVALID_ENTRY_METADATA);

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ExperimentManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ExperimentManagerServiceTest.java
@@ -60,6 +60,7 @@ public class ExperimentManagerServiceTest extends RestServerTest {
 
     private static final String TEST = "test";
     private static final @NonNull ImmutableSet<TraceModelStub> CONTEXT_SWITCH_SET = ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_STUB, CONTEXT_SWITCHES_UST_STUB);
+    private static final @NonNull ImmutableSet<TraceModelStub> CONTEXT_SWITCH_NOT_INITIALIZED_SET = ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
     private static final @NonNull ExperimentModelStub EXPECTED = new ExperimentModelStub(TEST, CONTEXT_SWITCH_SET);
 
     /**
@@ -71,9 +72,9 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         WebTarget traces = application.path(TRACES);
         WebTarget expTarget = application.path(EXPERIMENTS);
 
-        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_STUB);
-        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertEquals(CONTEXT_SWITCH_SET, getTraces(traces));
+        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
+        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertEquals(CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
 
         assertEquals("experiment set should be empty at this point", Collections.emptySet(), getExperiments(expTarget));
 
@@ -89,12 +90,12 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         ExperimentModelStub expStub = response.readEntity(ExperimentModelStub.class);
         assertEquals("Failed to POST the experiment", EXPECTED, expStub);
         assertEquals("Failed to add experiment to set of experiments", Collections.singleton(EXPECTED), getExperiments(expTarget));
-        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_SET, getTraces(traces));
+        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
         assertEquals("Failed to get the experiment by its UUID", EXPECTED, expTarget.path(expStub.getUUID().toString()).request().get(ExperimentModelStub.class));
 
         assertEquals("Failed to DELETE the experiment", EXPECTED, expTarget.path(expStub.getUUID().toString()).request().delete().readEntity(ExperimentModelStub.class));
         assertEquals("experiment set should be empty at this point", Collections.emptySet(), getExperiments(expTarget));
-        assertEquals("Deleting an experiment should not change the trace set", CONTEXT_SWITCH_SET, getTraces(traces));
+        assertEquals("Deleting an experiment should not change the trace set", CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
         response.close();
     }
 
@@ -107,9 +108,9 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         WebTarget traces = application.path(TRACES);
         WebTarget expTarget = application.path(EXPERIMENTS);
 
-        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_STUB);
-        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertEquals(null, CONTEXT_SWITCH_SET, getTraces(traces));
+        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
+        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertEquals(CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
 
         assertEquals("experiment set should be empty at this point", Collections.emptySet(), getExperiments(expTarget));
 
@@ -125,7 +126,7 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         ExperimentModelStub expStub = response.readEntity(ExperimentModelStub.class);
         assertEquals("Failed to POST the experiment", EXPECTED, expStub);
         assertEquals("Failed to add experiment to set of experiments", Collections.singleton(EXPECTED), getExperiments(expTarget));
-        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_SET, getTraces(traces));
+        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
         assertEquals("Failed to get the experiment by its UUID", EXPECTED, expTarget.path(expStub.getUUID().toString()).request().get(ExperimentModelStub.class));
         response.close();
 
@@ -135,13 +136,13 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         assertEquals("Status of second post", Status.OK.getStatusCode(), response2.getStatus());
         assertEquals("Failed to POST the experiment a second time", EXPECTED, expStub2);
         assertEquals("There should still be only one experiment", Collections.singleton(EXPECTED), getExperiments(expTarget));
-        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_SET, getTraces(traces));
+        assertEquals("Adding an experiment should not change the trace set", CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
         assertEquals("Failed to get the experiment by its UUID", EXPECTED, expTarget.path(expStub2.getUUID().toString()).request().get(ExperimentModelStub.class));
         response2.close();
 
         assertEquals("Failed to DELETE the experiment", EXPECTED, expTarget.path(expStub.getUUID().toString()).request().delete().readEntity(ExperimentModelStub.class));
         assertEquals("experiment set should be empty at this point", Collections.emptySet(), getExperiments(expTarget));
-        assertEquals("Deleting an experiment should not change the trace set", CONTEXT_SWITCH_SET, getTraces(traces));
+        assertEquals("Deleting an experiment should not change the trace set", CONTEXT_SWITCH_NOT_INITIALIZED_SET, getTraces(traces));
 
     }
 
@@ -154,10 +155,10 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         WebTarget traces = application.path(TRACES);
         WebTarget expTarget = application.path(EXPERIMENTS);
 
-        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_STUB);
-        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        TraceModelStub arm64Stub = assertPost(traces, ARM_64_KERNEL_STUB);
-        ImmutableSet<TraceModelStub> traceSet = ImmutableSet.of(CONTEXT_SWITCHES_UST_STUB, CONTEXT_SWITCHES_KERNEL_STUB, ARM_64_KERNEL_STUB);
+        TraceModelStub ustStub = assertPost(traces, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
+        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        TraceModelStub arm64Stub = assertPost(traces, ARM_64_KERNEL_NOT_INITIALIZED_STUB);
+        ImmutableSet<TraceModelStub> traceSet = ImmutableSet.of(CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, ARM_64_KERNEL_NOT_INITIALIZED_STUB);
         assertEquals(null, traceSet, getTraces(traces));
 
         assertEquals("experiment set should be empty at this point", Collections.emptySet(), getExperiments(expTarget));
@@ -226,8 +227,8 @@ public class ExperimentManagerServiceTest extends RestServerTest {
         WebTarget tracesTarget = applicationTarget.path(TRACES);
         WebTarget experimentsTarget = applicationTarget.path(EXPERIMENTS);
 
-        TraceModelStub ustStub = assertPost(tracesTarget, CONTEXT_SWITCHES_UST_STUB);
-        TraceModelStub kernelStub = assertPost(tracesTarget, CONTEXT_SWITCHES_KERNEL_STUB);
+        TraceModelStub ustStub = assertPost(tracesTarget, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
+        TraceModelStub kernelStub = assertPost(tracesTarget, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
 
         List<String> traceUUIDs = new ArrayList<>();
         traceUUIDs.add(ustStub.getUUID().toString());

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TraceManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TraceManagerServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Ericsson
+ * Copyright (c) 2018, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -57,17 +57,17 @@ public class TraceManagerServiceTest extends RestServerTest {
 
         assertTrue("Expected empty set of traces", getTraces(traces).isEmpty());
 
-        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
+        TraceModelStub kernelStub = assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
 
-        assertEquals(CONTEXT_SWITCHES_KERNEL_STUB, traces.path(kernelStub.getUUID().toString()).request().get(TraceModelStub.class));
+        assertEquals(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, traces.path(kernelStub.getUUID().toString()).request().get(TraceModelStub.class));
 
         assertEquals("Expected set of traces to contain trace2 stub",
-                Collections.singleton(CONTEXT_SWITCHES_KERNEL_STUB), getTraces(traces));
+                Collections.singleton(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB), getTraces(traces));
 
         Response deleteResponse = traces.path(kernelStub.getUUID().toString()).request().delete();
         int deleteCode = deleteResponse.getStatus();
         assertEquals("Failed to DELETE trace2, error code=" + deleteCode, 200, deleteCode);
-        assertEquals(CONTEXT_SWITCHES_KERNEL_STUB, deleteResponse.readEntity(TraceModelStub.class));
+        assertEquals(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, deleteResponse.readEntity(TraceModelStub.class));
 
         assertEquals("Trace should have been deleted", Collections.emptySet(), getTraces(traces));
     }
@@ -79,10 +79,10 @@ public class TraceManagerServiceTest extends RestServerTest {
     public void testWithTwoTraces() {
         WebTarget traces = getApplicationEndpoint().path(TRACES);
 
-        assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertPost(traces, CONTEXT_SWITCHES_UST_STUB);
+        assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertPost(traces, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
-        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_STUB, CONTEXT_SWITCHES_UST_STUB), getTraces(traces));
+        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB), getTraces(traces));
     }
 
     /**
@@ -93,17 +93,17 @@ public class TraceManagerServiceTest extends RestServerTest {
     public void testConflictingTraces() throws IOException {
         WebTarget traces = getApplicationEndpoint().path(TRACES);
 
-        assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_STUB), getTraces(traces));
+        assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB), getTraces(traces));
 
         // Post the trace a second time
-        assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_STUB), getTraces(traces));
+        assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB), getTraces(traces));
 
         // Post a trace with the same name but another path, the name does not
         // matter if the path is different, the trace will be added
-        assertPost(traces, ARM_64_KERNEL_STUB);
-        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_STUB, ARM_64_KERNEL_STUB), getTraces(traces));
+        assertPost(traces, ARM_64_KERNEL_NOT_INITIALIZED_STUB);
+        assertEquals(ImmutableSet.of(CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB, ARM_64_KERNEL_NOT_INITIALIZED_STUB), getTraces(traces));
     }
 
     /**
@@ -118,8 +118,8 @@ public class TraceManagerServiceTest extends RestServerTest {
     public void testWorkspaceStructure() throws CoreException, IOException {
         WebTarget traces = getApplicationEndpoint().path(TRACES);
 
-        assertPost(traces, CONTEXT_SWITCHES_KERNEL_STUB);
-        assertPost(traces, CONTEXT_SWITCHES_UST_STUB);
+        assertPost(traces, CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB);
+        assertPost(traces, CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB);
 
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -158,6 +158,12 @@ public abstract class RestServerTest {
     protected static TraceModelStub CONTEXT_SWITCHES_UST_STUB;
 
     /**
+     * {@link TraceModelStub} to represent the object returned by the server for
+     * {@link CtfTestTrace#CONTEXT_SWITCHES_UST} without metadata initialized.
+     */
+    protected static TraceModelStub CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB;
+
+    /**
      * The name used when posting the trace.
      */
     protected static final String CONTEXT_SWITCHES_UST_NAME = "ust";
@@ -181,6 +187,12 @@ public abstract class RestServerTest {
      * {@link CtfTestTrace#CONTEXT_SWITCHES_KERNEL}.
      */
     protected static TraceModelStub CONTEXT_SWITCHES_KERNEL_STUB;
+
+    /**
+     * {@link TraceModelStub} to represent the object returned by the server for
+     * {@link CtfTestTrace#CONTEXT_SWITCHES_KERNEL} without metadata initialized.
+     */
+    protected static TraceModelStub CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB;
 
     /**
      * The name used when posting the trace.
@@ -210,6 +222,12 @@ public abstract class RestServerTest {
      * {@link CtfTestTrace#ARM_64_BIT_HEADER}, with the same name as {@link #CONTEXT_SWITCHES_KERNEL_STUB}
      */
     protected static TraceModelStub ARM_64_KERNEL_STUB;
+
+    /**
+     * {@link TraceModelStub} to represent the object returned by the server for
+     * {@link CtfTestTrace#ARM_64_BIT_HEADER} without metadata initialized.
+     */
+    protected static TraceModelStub ARM_64_KERNEL_NOT_INITIALIZED_STUB;
 
     /**
      * The name used when posting the trace.
@@ -248,12 +266,15 @@ public abstract class RestServerTest {
     @BeforeClass
     public static void beforeTest() throws IOException {
         String contextSwitchesUstPath = FileLocator.toFileURL(CtfTestTrace.CONTEXT_SWITCHES_UST.getTraceURL()).getPath().replaceAll("/$", "");
+        CONTEXT_SWITCHES_UST_NOT_INITIALIZED_STUB = new TraceModelStub(CONTEXT_SWITCHES_UST_NAME, contextSwitchesUstPath, Collections.EMPTY_MAP);
         CONTEXT_SWITCHES_UST_STUB = new TraceModelStub(CONTEXT_SWITCHES_UST_NAME, contextSwitchesUstPath, CONTEXT_SWITCHES_UST_PROPERTIES);
 
         String contextSwitchesKernelPath = FileLocator.toFileURL(CtfTestTrace.CONTEXT_SWITCHES_KERNEL.getTraceURL()).getPath().replaceAll("/$", "");
+        CONTEXT_SWITCHES_KERNEL_NOT_INITIALIZED_STUB = new TraceModelStub(CONTEXT_SWITCHES_KERNEL_NAME, contextSwitchesKernelPath, Collections.EMPTY_MAP);
         CONTEXT_SWITCHES_KERNEL_STUB = new TraceModelStub(CONTEXT_SWITCHES_KERNEL_NAME, contextSwitchesKernelPath, CONTEXT_SWITCHES_KERNEL_PROPERTIES);
 
         String arm64Path = FileLocator.toFileURL(CtfTestTrace.ARM_64_BIT_HEADER.getTraceURL()).getPath().replaceAll("/$", "");
+        ARM_64_KERNEL_NOT_INITIALIZED_STUB = new TraceModelStub(ARM_64_KERNEL_NAME, arm64Path, Collections.EMPTY_MAP);
         ARM_64_KERNEL_STUB = new TraceModelStub(ARM_64_KERNEL_NAME, arm64Path, ARM_64_KERNEL_PROPERTIES);
 
         ImmutableList.Builder<DataProviderDescriptorStub> b = ImmutableList.builder();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/Experiment.java
@@ -14,10 +14,13 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import java.io.Serializable;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -82,8 +85,11 @@ public final class Experiment implements Serializable {
      * @return the experiment model
      */
     public static Experiment from(TmfExperiment experiment, UUID expUUID) {
-        List<UUID> traceUUIDs = ExperimentManagerService.getTraceUUIDs(expUUID);
-        Set<Trace> traces = new LinkedHashSet<>(Lists.transform(traceUUIDs, uuid -> Trace.from(TraceManagerService.getOrCreateTraceInstance(uuid), uuid)));
+        Map<UUID, ITmfTrace> uuidToTraceInstances = ExperimentManagerService.getTraceInstances(expUUID);
+        Set<Trace> traces = uuidToTraceInstances.entrySet().stream()
+            .map(entry -> Trace.from(entry.getValue(), entry.getKey()))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
         return new Experiment(experiment.getName(),
                 expUUID,
                 experiment.getNbEvents(),


### PR DESCRIPTION
A separate trace instance was created to provide metadata info when a trace is queried. This commit removed the creation of that separate instance and open provide metadata info when the experiment is created.