### PR TITLE
Swagger updates for global and output configuration

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/ConfigurationManagerServiceTest.java
@@ -358,7 +358,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
             parameters.put(PATH, path);
         }
         return endpoint.request(MediaType.APPLICATION_JSON)
-                .post(Entity.json(new ConfigurationQueryParameters(null, null, null, parameters)));
+                .post(Entity.json(new ConfigurationQueryParameters(null, null, parameters)));
     }
 
     private static Response createJsonConfig(String jsonFileName) throws URISyntaxException, IOException {
@@ -371,7 +371,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
 
         Map<String, Object> params = readParametersFromJson(jsonFileName);
         return endpoint.request(MediaType.APPLICATION_JSON)
-                .post(Entity.json(new ConfigurationQueryParameters(null, null, null, params)));
+                .post(Entity.json(new ConfigurationQueryParameters(null, null, params)));
     }
 
     private static Response updateConfig(String path, String id) {
@@ -403,7 +403,7 @@ public class ConfigurationManagerServiceTest extends RestServerTest {
             parameters.put(PATH, path);
         }
         return endpoint.request(MediaType.APPLICATION_JSON)
-                .put(Entity.json(new ConfigurationQueryParameters(null, null, null, parameters)));
+                .put(Entity.json(new ConfigurationQueryParameters(null, null, parameters)));
     }
 
     private static Response deleteConfig(String id) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -37,7 +37,7 @@ import javax.ws.rs.core.Response;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.ConfigurationQueryParameters;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.OutputConfigurationQueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.QueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp.TraceServerConfiguration;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp.WebApplication;
@@ -627,7 +627,7 @@ public abstract class RestServerTest {
     @SuppressWarnings("null")
     public static DataProviderDescriptorStub assertDpPost(WebTarget dpConfigEndpoint, ITmfConfiguration configuration) {
         try (Response response = dpConfigEndpoint.request().post(Entity.json(
-                new ConfigurationQueryParameters(configuration.getName(), configuration.getDescription(), configuration.getSourceTypeId(), configuration.getParameters())))) {
+                new OutputConfigurationQueryParameters(configuration.getName(), configuration.getDescription(), configuration.getSourceTypeId(), configuration.getParameters())))) {
             int code = response.getStatus();
             assertEquals("Failed to POST " + configuration.getName() + ", error code=" + code, 200, code);
             DataProviderDescriptorStub result = response.readEntity(DataProviderDescriptorStub.class);
@@ -651,7 +651,7 @@ public abstract class RestServerTest {
     @SuppressWarnings("null")
     public static Response assertDpPostWithErrors(WebTarget dpConfigEndpoint, ITmfConfiguration configuration) {
         return dpConfigEndpoint.request().post(Entity.json(
-                new ConfigurationQueryParameters(configuration.getName(), configuration.getDescription(), configuration.getSourceTypeId(), configuration.getParameters())));
+                new OutputConfigurationQueryParameters(configuration.getName(), configuration.getDescription(), configuration.getSourceTypeId(), configuration.getParameters())));
     }
 
     /**

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Configuration.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Configuration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Ericsson
+ * Copyright (c) 2023, 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Contributes to the model used for TSP swagger-core annotations.
  */
 @NonNullByDefault
+@Schema(description = "Configuration instance describing user provided configuration parameters.")
 public interface Configuration {
     /**
      * @return the name of configuration instance

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ConfigurationQueryParameters.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2023 Ericsson
+ * Copyright (c) 2024 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -13,48 +13,25 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Contributes to the model used for TSP swagger-core annotations.
  */
 public interface ConfigurationQueryParameters {
-
     /**
-     * @return The parameters.
+     * @return the name of the configuration
      */
-    @NonNull
-    @Schema(required = true)
-    ConfigurationParameters getParameters();
-
+    @Schema(required = true, description = "Unique name of the configuration.")
+    String getName();
     /**
-     * Configuration parameters as per current trace-server protocol.
+     * @return the description of the configuration
      */
-    interface ConfigurationParameters {
-        /**
-         * @return the name of the configuration
-         */
-        @Schema(required = true, description = "Unique name of the configuration. If omitted a unique name will be generated.")
-        String getName();
-        /**
-         * @return the description of the configuration
-         */
-        @Schema(required = false, description = "Optional description of the configuration.")
-        String getDescription();
-        /**
-         * @return the typeId of the configuration according to the {@link ConfigurationSourceType}
-         */
-        @Schema(required = false, description = "Optional typeId of the configuration according to the corresponding ConfigurationTypeDescriptor. Omit if it's part of the endpoint URI.")
-        @JsonProperty("typeId")
-        String getTypeId();
-        /**
-         * @return parameters map for custom parameters as defined in the corresponding {@link ConfigurationSourceType}
-         */
-        @Schema(required = true, description = "Parameters as specified in the schema or list of ConfigurationParameterDescriptor of the corresponding ConfigurationTypeDescriptor.")
-        Map<String, Object> getParameters();
-    }
+    @Schema(required = false, description = "Optional description of the configuration.")
+    String getDescription();
+    /**
+     * @return parameters map for custom parameters as defined in the corresponding {@link ConfigurationSourceType}
+     */
+    @Schema(required = true, description = "Parameters as specified in the schema or list of ConfigurationParameterDescriptor of the corresponding ConfigurationTypeDescriptor.")
+    Map<String, Object> getParameters();
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputConfigurationQueryParameters.java
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (c) 2023, 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(allOf = ConfigurationQueryParameters.class)
+public interface OutputConfigurationQueryParameters {
+    /**
+     * @return the typeId of the configuration according to the
+     *         {@link ConfigurationSourceType}
+     */
+    @Schema(required = true, description = "TypeId of the configuration according to the corresponding ConfigurationTypeDescriptor.")
+    @JsonProperty("typeId")
+    String getTypeId();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/ConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/ConfigurationQueryParameters.java
@@ -23,7 +23,6 @@ import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 public class ConfigurationQueryParameters {
     private @NonNull String name;
     private @NonNull String description;
-    private @NonNull String typeId;
     private @NonNull Map<String, Object> parameters;
 
     /**
@@ -35,7 +34,6 @@ public class ConfigurationQueryParameters {
         this.parameters = new HashMap<>();
         this.name = TmfConfiguration.UNKNOWN;
         this.description = TmfConfiguration.UNKNOWN;
-        this.typeId = TmfConfiguration.UNKNOWN;
     }
 
     /**
@@ -51,11 +49,10 @@ public class ConfigurationQueryParameters {
      * @param parameters
      *            Map of parameters
      */
-    public ConfigurationQueryParameters(String name, String description, String typeId, Map<String, Object> parameters) {
+    public ConfigurationQueryParameters(String name, String description, Map<String, Object> parameters) {
         this.parameters = parameters != null ? parameters : new HashMap<>();
         this.name = name == null ? TmfConfiguration.UNKNOWN : name;
         this.description = description == null ? TmfConfiguration.UNKNOWN : description;
-        this.typeId = typeId == null ? TmfConfiguration.UNKNOWN : typeId;
     }
 
     /**
@@ -73,13 +70,6 @@ public class ConfigurationQueryParameters {
     }
 
     /**
-     * @return the type ID of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
-     */
-    @NonNull  public String getTypeId() {
-        return typeId;
-    }
-
-    /**
      * @return Map of parameters or empty map if not provided
      */
     @NonNull public Map<String, Object> getParameters() {
@@ -89,7 +79,6 @@ public class ConfigurationQueryParameters {
     @SuppressWarnings("nls")
     @Override
     public String toString() {
-        return "ConfigurationQueryParameters [name=" + getName() + ", description=" + getDescription()
-           +", typeId=" + getTypeId() + "parameters=" + getParameters() + "]";
+        return "ConfigurationQueryParameters [name=" + getName() + ", description=" + getDescription() + ", parameters=" + getParameters() + "]";
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/OutputConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/OutputConfigurationQueryParameters.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
+
+/**
+ * Definition of a parameters object received by the server from a client for configurations.
+ */
+public class OutputConfigurationQueryParameters extends ConfigurationQueryParameters {
+    private @NonNull String typeId;
+
+    /**
+     * Constructor for Jackson
+     */
+    public OutputConfigurationQueryParameters() {
+        // Default constructor for Jackson
+        super();
+        this.typeId = TmfConfiguration.UNKNOWN;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name
+     *            the name of the configuration
+     * @param description
+     *            the description of the configuration
+     * @param typeId
+     *            the typeId of the configuration
+     *
+     * @param parameters
+     *            Map of parameters
+     */
+    public OutputConfigurationQueryParameters(String name, String description, String typeId, Map<String, Object> parameters) {
+        super(name, description, parameters);
+        this.typeId = typeId == null ? TmfConfiguration.UNKNOWN : typeId;
+    }
+
+    /**
+     * @return the type ID of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
+     */
+    @NonNull public String getTypeId() {
+        return typeId;
+    }
+
+    @SuppressWarnings("nls")
+    @Override
+    public String toString() {
+        return "OutputConfigurationQueryParameters [name=" + getName() + ", description=" + getDescription()
+           +", typeId=" + getTypeId() + ", parameters=" + getParameters() + "]";
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ConfigurationManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ConfigurationManagerService.java
@@ -142,8 +142,7 @@ public class ConfigurationManagerService {
     })
     public Response postConfiguration(@Parameter(description = CFG_TYPE_ID) @PathParam("typeId") String typeId,
             @RequestBody(description = CFG_CREATE_DESC + " " + CFG_KEYS_DESC, content = {
-                    @Content(examples = @ExampleObject("{\"parameters\":{" + CFG_PATH_EX +
-                            "}}"), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ConfigurationQueryParameters.class))
+                    @Content(examples = @ExampleObject(CFG_PATH_EX), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ConfigurationQueryParameters.class))
             }, required = true) ConfigurationQueryParameters queryParameters) {
         ITmfConfigurationSource configurationSource = fConfigSourceManager.getConfigurationSource(typeId);
         if (configurationSource == null) {
@@ -223,8 +222,7 @@ public class ConfigurationManagerService {
     public Response putConfiguration(@Parameter(description = CFG_TYPE_ID) @PathParam("typeId") String typeId,
             @Parameter(description = CFG_CONFIG_ID) @PathParam("configId") String configId,
             @RequestBody(description = CFG_UPDATE_DESC + " " + CFG_KEYS_DESC, content = {
-                    @Content(examples = @ExampleObject("{\"parameters\":{" + CFG_PATH_EX +
-                            "}}"), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ConfigurationQueryParameters.class))
+                    @Content(examples = @ExampleObject(CFG_PATH_EX), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ConfigurationQueryParameters.class))
             }, required = true) ConfigurationQueryParameters queryParameters) {
         ITmfConfigurationSource configurationSource = fConfigSourceManager.getConfigurationSource(typeId);
         if (configurationSource == null) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ANN;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_CREATE_DESC;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_KEYS_DESC;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DP_CFG_EX;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_TYPE_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS_EX;
@@ -1266,7 +1267,7 @@ public class DataProviderService {
                 @Parameter(description = EXP_UUID) @PathParam("expUUID") UUID expUUID,
                 @Parameter(description = OUTPUT_ID) @PathParam("outputId") String outputId,
                 @RequestBody(description = CFG_CREATE_DESC + " " + CFG_KEYS_DESC, content = {
-                        @Content(schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.OutputConfigurationQueryParameters.class))
+                        @Content(examples = @ExampleObject(DP_CFG_EX), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.OutputConfigurationQueryParameters.class))
                 }, required = true) OutputConfigurationQueryParameters queryParameters) {
 
         try (FlowScopeLog scope = new FlowScopeLogBuilder(LOGGER, Level.FINE, "DataProviderService#createDataProvider") //$NON-NLS-1$

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -55,8 +55,8 @@ import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.re
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.OCG;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ONE_OF;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.OUTPUT_ID;
-import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PROVIDER_NOT_FOUND;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PROVIDER_CONFIG_NOT_FOUND;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PROVIDER_NOT_FOUND;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.STY;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.TABLE_TIMES;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.TGR;
@@ -125,6 +125,7 @@ import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.XYTreeResponse;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.ConfigurationQueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.GenericView;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.OutputConfigurationQueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.QueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.TableColumnHeader;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.TreeModelWrapper;
@@ -1256,7 +1257,7 @@ public class DataProviderService {
     @Tag(name = OCG)
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Get the list of outputs for this configuration", responses = {
+    @Operation(summary = "Get a derived data provider from a input configuration", responses = {
             @ApiResponse(responseCode = "200", description = "Returns a list of output provider descriptors", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataProvider.class)))),
             @ApiResponse(responseCode = "400", description = INVALID_PARAMETERS, content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = PROVIDER_CONFIG_NOT_FOUND, content = @Content(schema = @Schema(implementation = String.class))),
@@ -1265,8 +1266,8 @@ public class DataProviderService {
                 @Parameter(description = EXP_UUID) @PathParam("expUUID") UUID expUUID,
                 @Parameter(description = OUTPUT_ID) @PathParam("outputId") String outputId,
                 @RequestBody(description = CFG_CREATE_DESC + " " + CFG_KEYS_DESC, content = {
-                        @Content(schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ConfigurationQueryParameters.class))
-                }, required = true) ConfigurationQueryParameters queryParameters) {
+                        @Content(schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.OutputConfigurationQueryParameters.class))
+                }, required = true) OutputConfigurationQueryParameters queryParameters) {
 
         try (FlowScopeLog scope = new FlowScopeLogBuilder(LOGGER, Level.FINE, "DataProviderService#createDataProvider") //$NON-NLS-1$
                 .setCategory(outputId).build()) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -152,7 +152,7 @@ public final class EndpointConstants {
      * Swagger @RequestBody example constants, named after their parameter name,
      * without the common 'requested' prefix; alphabetical order.
      */
-    static final String CFG_PATH_EX = "\"path\": \"/home/user/test.xml\""; //$NON-NLS-1$
+    static final String CFG_PATH_EX = "{\"name\": \"test.xml\", \"description\": \"Configuration with test.xml\", \"parameters\":{ \"path\": \"/home/user/test.xml\" }}"; //$NON-NLS-1$
     static final String COLUMNS_EX = "\"" + REQUESTED_COLUMN_IDS_KEY + "\": [0, 1, 2],"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String COUNT_EX = "\"" + REQUESTED_TABLE_COUNT_KEY + "\": 100,"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String DIRECTION_EX = "\"" + TABLE_SEARCH_DIRECTION_KEY + "\": \"NEXT\""; //$NON-NLS-1$ //$NON-NLS-2$
@@ -167,6 +167,7 @@ public final class EndpointConstants {
     static final String FILTER_QUERY_PARAMETERS_EX = "\"" + FILTER_QUERY_PARAMETERS_KEY + "\": {\"" + FILTER_QUERY_STRATEGY + "\": \"SAMPLED\", \"" + FILTER_EXPRESSIONS_MAP + "\": {\"1\":[\"openat\", \"duration>10ms\"]}}"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     static final String TIMERANGE_EX_TREE = "\"" + REQUESTED_TIMERANGE_KEY + "\": {\"start\": 111111111, \"end\": 222222222}"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String TIMES_EX_TT = "\"" + REQUESTED_TIME_KEY + "\": [111200000],"; //$NON-NLS-1$ //$NON-NLS-2$
+    static final String DP_CFG_EX = "{\"name\": \"Follow My-thread\", \"description\": \"My-thread on even CPUs\", \"typeId\": \"my.config.source.type.id\", \"parameters\":{ \"threads\": \"My-thread\", \"cpus\": [0,2,4,6] }}"; //$NON-NLS-1$
 
     /** Swagger @ApiResponse description constants reused, or centralized. */
     static final String CANNOT_READ = "Cannot read this trace type"; //$NON-NLS-1$


### PR DESCRIPTION
- Update documentation of Configuration and ConfigurationQueryParameters. 
Add name and description ConfigurationQueryParameters used for global configuration.
- Add configuration service per output (data provider)
This addition enables clients to create derived data providers from an existing data provider. This change also includes updates the "DataProvider" descriptor to include optional parent ID and configuration object to be included in derived data providers.




Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>