### PR TITLE
callstack: remove xml extension

### DIFF
--- a/callstack/org.eclipse.tracecompass.incubator.callstack.core.tests/plugin.xml
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.core.tests/plugin.xml
@@ -12,11 +12,5 @@
          </tracetype>
       </module>
    </extension>
-   <extension
-         point="org.eclipse.linuxtools.tmf.analysis.xml.core.files">
-      <xmlfile
-            file="test_xml_files/test_callstack.xml">
-      </xmlfile>
-   </extension>
 
 </plugin>

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.core/plugin.xml
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.core/plugin.xml
@@ -2,9 +2,6 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension
-         point="org.eclipse.tracecompass.tmf.analysis.xml.core.xsd">
-   </extension>
-   <extension
          point="org.eclipse.linuxtools.tmf.core.analysis">
       <module
             analysis_module="org.eclipse.tracecompass.incubator.callstack.core.lttng2.ust.LttngUstCallStackAnalysis"


### PR DESCRIPTION
The extension was not removed in the previous patch which creates an error when launching Trace Compass. This commit removes the extension from the plugin.xml.

Bernd Hufmann <bernd.hufmann@ericsson.com>