### PR TITLE
Return deleted data provider descriptor and related swagger doc updates

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderServiceTest.java
@@ -772,6 +772,8 @@ public class DataProviderServiceTest extends RestServerTest {
         try (Response response = dpDeletionEndpoint.request().delete()) {
             assertNotNull(response);
             assertEquals(Status.OK.getStatusCode(), response.getStatus());
+            DataProviderDescriptorStub deletedDp = response.readEntity(DataProviderDescriptorStub.class);
+            assertEquals(derivedDp, deletedDp);
         }
     }
 

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -14,6 +14,7 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ANN;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_CREATE_DESC;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_KEYS_DESC;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_OUTPUT_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_TYPE_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS_EX;
@@ -1249,9 +1250,9 @@ public class DataProviderService {
      * @param expUUID
      *            desired experiment UUID
      * @param outputId
-     *            Output ID for the data provider to query
+     *            ID of the output provider to create a derived output from
      * @param queryParameters
-     *            the query parameters used to create a data provider
+     *            the query parameters used to create a output provider
      * @return a list of data provider descriptors
      */
     @SuppressWarnings("null")
@@ -1261,13 +1262,13 @@ public class DataProviderService {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get a derived data provider from a input configuration", responses = {
-            @ApiResponse(responseCode = "200", description = "Returns a list of output provider descriptors", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DataProvider.class)))),
+            @ApiResponse(responseCode = "200", description = "Returns the derived data provider descriptor.", content = @Content(schema = @Schema(implementation = DataProvider.class))),
             @ApiResponse(responseCode = "400", description = INVALID_PARAMETERS, content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = PROVIDER_CONFIG_NOT_FOUND, content = @Content(schema = @Schema(implementation = String.class))),
     })
-    public Response createDataProvider(
+    public Response createProvider(
                 @Parameter(description = EXP_UUID) @PathParam("expUUID") UUID expUUID,
-                @Parameter(description = OUTPUT_ID) @PathParam("outputId") String outputId,
+                @Parameter(description = CFG_OUTPUT_ID) @PathParam("outputId") String outputId,
                 @RequestBody(description = CFG_CREATE_DESC + " " + CFG_KEYS_DESC, content = {
                         @Content(examples = @ExampleObject(DP_CFG_EX), schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.OutputConfigurationQueryParameters.class))
                 }, required = true) OutputConfigurationQueryParameters queryParameters) {

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -14,16 +14,17 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ANN;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_CREATE_DESC;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_KEYS_DESC;
-import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DP_CFG_EX;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CFG_TYPE_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COLUMNS_EX;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.CONSISTENT_PARENT;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COUNT;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.COUNT_EX;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DERIVED_OUTPUT_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DIRECTION;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DIRECTION_COUNT;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DIRECTION_EX;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DP_CFG_EX;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.DT;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ELEMENT;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ELEMENT_EX;
@@ -56,6 +57,7 @@ import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.re
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.OCG;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.ONE_OF;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.OUTPUT_ID;
+import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PARENT_OUTPUT_ID;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PROVIDER_CONFIG_NOT_FOUND;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.PROVIDER_NOT_FOUND;
 import static org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants.STY;
@@ -1311,29 +1313,29 @@ public class DataProviderService {
     }
 
     /**
-     * DELETE a derived data provider from created by a given data provider
+     * DELETE a derived data provider created from a given data provider
      *
      * @param expUUID
      *            desired experiment UUID
      * @param outputId
-     *            Output ID for the data provider to query
+     *            Output ID of the parent output provider
      * @param derivedOutputId
-     *            Output ID for the data provider to delete
+     *            Output ID for the derived output provider to delete
      * @return status and the deleted configuration instance, if successful
      */
     @DELETE
     @Path("/{outputId}/{derivedOutputId}")
     @Tag(name = OCG)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Delete a configuration instance of a given configuration type", responses = {
-            @ApiResponse(responseCode = "200", description = "The derived data provider (and it's configuration) was successfully deleted", content = @Content(schema = @Schema(implementation = org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.Configuration.class))),
+    @Operation(summary = "Delete a derived output (and its configuration).", responses = {
+            @ApiResponse(responseCode = "200", description = "Returns the deleted derived data provider descriptor. The derived data provider (and its configuration) was successfully deleted.", content = @Content(schema = @Schema(implementation = DataProvider.class))),
             @ApiResponse(responseCode = "400", description = INVALID_PARAMETERS, content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = PROVIDER_CONFIG_NOT_FOUND, content = @Content(schema = @Schema(implementation = String.class))),
     })
-    public Response deleteDerivedOutput(
+    public Response deleteDerivedProvider(
             @Parameter(description = EXP_UUID) @PathParam("expUUID") UUID expUUID,
-            @Parameter(description = OUTPUT_ID) @PathParam("outputId") String outputId,
-            @Parameter(description = OUTPUT_ID) @PathParam("derivedOutputId") String derivedOutputId) {
+            @Parameter(description = PARENT_OUTPUT_ID) @PathParam("outputId") String outputId,
+            @Parameter(description = DERIVED_OUTPUT_ID) @PathParam("derivedOutputId") String derivedOutputId) {
 
         if (outputId == null) {
             return Response.status(Status.BAD_REQUEST).entity(MISSING_OUTPUTID + " (parent)").build(); //$NON-NLS-1$
@@ -1370,7 +1372,7 @@ public class DataProviderService {
                 return Response.status(Status.NOT_FOUND).entity(NO_SUCH_PROVIDER).build();
             }
             configurator.removeDataProviderDescriptor(experiment, derivedDescriptor);
-            return Response.ok().build();
+            return Response.ok(derivedDescriptor).build();
         } catch (TmfConfigurationException e) {
             return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
         }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -108,8 +108,9 @@ public final class EndpointConstants {
      * Swagger @Parameter description constants, named after their parameter
      * name; alphabetical order.
      */
-    static final String CFG_TYPE_ID = "The configuration source type ID"; //$NON-NLS-1$
     static final String CFG_CONFIG_ID = "The configuration instance ID"; //$NON-NLS-1$
+    static final String CFG_OUTPUT_ID = "ID of the output provider to create a derived output from"; //$NON-NLS-1$
+    static final String CFG_TYPE_ID = "The configuration source type ID"; //$NON-NLS-1$
     static final String DERIVED_OUTPUT_ID = "ID of the derived output provider"; //$NON-NLS-1$
     static final String EXP_UUID = "UUID of the experiment to query"; //$NON-NLS-1$
     static final String MARKER_SET_ID = "The optional requested marker set's id"; //$NON-NLS-1$

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -110,9 +110,11 @@ public final class EndpointConstants {
      */
     static final String CFG_TYPE_ID = "The configuration source type ID"; //$NON-NLS-1$
     static final String CFG_CONFIG_ID = "The configuration instance ID"; //$NON-NLS-1$
+    static final String DERIVED_OUTPUT_ID = "ID of the derived output provider"; //$NON-NLS-1$
     static final String EXP_UUID = "UUID of the experiment to query"; //$NON-NLS-1$
     static final String MARKER_SET_ID = "The optional requested marker set's id"; //$NON-NLS-1$
     static final String OUTPUT_ID = "ID of the output provider to query"; //$NON-NLS-1$
+    static final String PARENT_OUTPUT_ID = "ID of the parent output provider"; //$NON-NLS-1$
     static final String TRACE_UUID = "UUID of the trace to query"; //$NON-NLS-1$
 
     /**


### PR DESCRIPTION
- server: Return derived data provider descriptor when deleting it.
Update swagger description for deletion and method name.
- swagger: Fix response description for successful DP creation.
Update also method name.


Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>