### PR TITLE
Remove name/description from InAndOut configuration schema

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/schema/in-and-out-analysis.json
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/schema/in-and-out-analysis.json
@@ -5,14 +5,6 @@
     "description": "Custom Execution Analysis schema",
     "type": "object",
     "properties": {
-        "name" : {
-            "type": "string",
-            "description": "The name of this InAndOut configuration"
-        },
-        "description" : {
-            "type": "string",
-            "description": "The descrition of this InAndOut configuration"
-        },
         "specifiers": {
             "description": "array specifiers",
             "type": "array",


### PR DESCRIPTION
The name and description are default parameters for configurations and don't need to be part of the schema for the custom parameters of InAndOut analyses.

This PR is a fix-up to #88.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>