### PR TITLE
Align OutputConfigurationQueryParameter/Configuration for sourceTypeId

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputConfigurationQueryParameters.java
@@ -24,7 +24,7 @@ public interface OutputConfigurationQueryParameters {
      * @return the typeId of the configuration according to the
      *         {@link ConfigurationSourceType}
      */
-    @Schema(required = true, description = "TypeId of the configuration according to the corresponding ConfigurationTypeDescriptor.")
-    @JsonProperty("typeId")
-    String getTypeId();
+    @Schema(required = true, description = "The type ID of the corresponding ConfigurationSourceType defined by this output.")
+    @JsonProperty("sourceTypeId")
+    String getSourceTypeId();
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/OutputConfigurationQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/OutputConfigurationQueryParameters.java
@@ -20,7 +20,7 @@ import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
  * Definition of a parameters object received by the server from a client for configurations.
  */
 public class OutputConfigurationQueryParameters extends ConfigurationQueryParameters {
-    private @NonNull String typeId;
+    private @NonNull String sourceTypeId;
 
     /**
      * Constructor for Jackson
@@ -28,7 +28,7 @@ public class OutputConfigurationQueryParameters extends ConfigurationQueryParame
     public OutputConfigurationQueryParameters() {
         // Default constructor for Jackson
         super();
-        this.typeId = TmfConfiguration.UNKNOWN;
+        this.sourceTypeId = TmfConfiguration.UNKNOWN;
     }
 
     /**
@@ -38,28 +38,28 @@ public class OutputConfigurationQueryParameters extends ConfigurationQueryParame
      *            the name of the configuration
      * @param description
      *            the description of the configuration
-     * @param typeId
-     *            the typeId of the configuration
+     * @param sourceTypeId
+     *            the typeId of the configuration source
      *
      * @param parameters
      *            Map of parameters
      */
-    public OutputConfigurationQueryParameters(String name, String description, String typeId, Map<String, Object> parameters) {
+    public OutputConfigurationQueryParameters(String name, String description, String sourceTypeId, Map<String, Object> parameters) {
         super(name, description, parameters);
-        this.typeId = typeId == null ? TmfConfiguration.UNKNOWN : typeId;
+        this.sourceTypeId = sourceTypeId == null ? TmfConfiguration.UNKNOWN : sourceTypeId;
     }
 
     /**
      * @return the type ID of configuration or {@link TmfConfiguration#UNKNOWN} if not provided
      */
-    @NonNull public String getTypeId() {
-        return typeId;
+    @NonNull public String getSourceTypeId() {
+        return sourceTypeId;
     }
 
     @SuppressWarnings("nls")
     @Override
     public String toString() {
         return "OutputConfigurationQueryParameters [name=" + getName() + ", description=" + getDescription()
-           +", typeId=" + getTypeId() + ", parameters=" + getParameters() + "]";
+           +", typeId=" + getSourceTypeId() + ", parameters=" + getParameters() + "]";
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -1309,7 +1309,7 @@ public class DataProviderService {
             ITmfConfiguration inputConfig = new TmfConfiguration.Builder()
                     .setName(queryParameters.getName())
                     .setDescription(queryParameters.getDescription())
-                    .setSourceTypeId(queryParameters.getTypeId())
+                    .setSourceTypeId(queryParameters.getSourceTypeId())
                     .setParameters(queryParameters.getParameters())
                     .build();
             String typeId = inputConfig.getSourceTypeId();


### PR DESCRIPTION
In the OutputConfigurationQueryParameter the configuration source type id was called typeId and it creates a Configuration object where the same field is called sourceTypeId for the same field. When serializing the Configuration in the derived DataProviderDescriptor over TSP the field is called sourceTypeId and this is not consistent. The returned Configuration should have the exact field names that are used when creating the data provider and the respective configuration.

The Configuration is already API while OutputConfigurationQueryParameter is not, and it's better to change the name there.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>