### PR TITLE
Cherry picks: Fix trace server version and display

### DIFF
--- a/skeleton/scripts/update_version.sh
+++ b/skeleton/scripts/update_version.sh
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2022 Ericsson
+# Copyright (c) 2016, 2024 Ericsson
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -56,3 +56,6 @@ find ../../rcp/org.eclipse.tracecompass.incubator.rcp.product/ -name "*.product"
 #Update .product trace-server/org.eclipse.tracecompass.incubator.trace.server.product/(*/)traceserver.product
 find ../../trace-server/org.eclipse.tracecompass.incubator.trace.server.product/ -name "*.product" -type f -exec sed -i -e s/$oldVersion/$newVersion/g {} \;
 
+#Update rest.core plugin trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF.
+#This version is retrieved to show the server version and hence has to match the trace server product version
+sed -i -e s/$oldVersion.qualifier/$newVersion.qualifier/g ../../trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core;singleton:=true
-Bundle-Version: 0.1.11.qualifier
+Bundle-Version: 0.12.0.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.Activator
 Bundle-ActivationPolicy: lazy

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/IdentifierService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/IdentifierService.java
@@ -72,7 +72,7 @@ public class IdentifierService {
 
         if (product != null) {
             Version version = product.getDefiningBundle().getVersion();
-            response.setVersion(version.getMajor() + SEPARATOR + version.getMicro() + SEPARATOR + version.getMinor());
+            response.setVersion(version.getMajor() + SEPARATOR + version.getMinor() + SEPARATOR + version.getMicro());
             String qualifier = version.getQualifier();
             if (!QUALIFIER.equalsIgnoreCase(qualifier) && qualifier != null) {
                 response.setBuildTime(qualifier);


### PR DESCRIPTION
Cherry-picks of commits of PR #122 

Fixes #121 in stable-10.2 branch, which is compatible with Trace Compass 10.2 release.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>