### PR TITLE
ros2: support client/service instrumentation

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/Activator.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/Activator.java
@@ -22,9 +22,11 @@ import org.eclipse.tracecompass.incubator.internal.ros2.core.model.messages.Ros2
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.messages.Ros2TakeInstance;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.messages.Ros2TimerCallbackInstance;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2CallbackObject;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2ClientObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2NodeObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2ObjectHandle;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2PublisherObject;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2ServiceObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2SubscriptionObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2TimerObject;
 import org.eclipse.tracecompass.internal.provisional.statesystem.core.statevalue.CustomStateValue;
@@ -65,6 +67,8 @@ public class Activator extends TraceCompassActivator {
         CustomStateValue.registerCustomFactory(Ros2SubscriptionObject.CUSTOM_TYPE_ID, Ros2SubscriptionObject.ROS2_SUBSCRIPTION_OBJECT_VALUE_FACTORY);
         CustomStateValue.registerCustomFactory(Ros2TimerObject.CUSTOM_TYPE_ID, Ros2TimerObject.ROS2_TIMER_OBJECT_VALUE_FACTORY);
         CustomStateValue.registerCustomFactory(Ros2CallbackObject.CUSTOM_TYPE_ID, Ros2CallbackObject.ROS2_CALLBACK_OBJECT_VALUE_FACTORY);
+        CustomStateValue.registerCustomFactory(Ros2ClientObject.CUSTOM_TYPE_ID, Ros2ClientObject.ROS2_CLIENT_OBJECT_VALUE_FACTORY);
+        CustomStateValue.registerCustomFactory(Ros2ServiceObject.CUSTOM_TYPE_ID, Ros2ServiceObject.ROS2_SERVICE_OBJECT_VALUE_FACTORY);
         // Instances (for messages analysis)
         CustomStateValue.registerCustomFactory(Ros2PubInstance.CUSTOM_TYPE_ID, Ros2PubInstance.ROS2_PUB_INSTANCE_VALUE_FACTORY);
         CustomStateValue.registerCustomFactory(Ros2TakeInstance.CUSTOM_TYPE_ID, Ros2TakeInstance.ROS2_TAKE_INSTANCE_VALUE_FACTORY);

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/Ros2ObjectTimeGraphEntryModel.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/Ros2ObjectTimeGraphEntryModel.java
@@ -16,8 +16,10 @@ import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2ClientObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2NodeObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2PublisherObject;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2ServiceObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2SubscriptionObject;
 import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Ros2TimerObject;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphEntryModel;
@@ -72,6 +74,10 @@ public class Ros2ObjectTimeGraphEntryModel extends TimeGraphEntryModel {
             return ((Ros2PublisherObject) object).getTopicName();
         case SUBSCRIPTION:
             return ((Ros2SubscriptionObject) object).getTopicName();
+        case CLIENT:
+            return ((Ros2ClientObject) object).getTopicName();
+        case SERVICE:
+            return ((Ros2ServiceObject) object).getTopicName();
         case TIMER:
             return getTimerPeriodAsString((Ros2TimerObject) object);
         default:

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/Ros2ObjectTimeGraphEntryModelType.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/Ros2ObjectTimeGraphEntryModelType.java
@@ -25,6 +25,10 @@ public enum Ros2ObjectTimeGraphEntryModelType {
     PUBLISHER,
     /** Subscription */
     SUBSCRIPTION,
+    /** Client */
+    CLIENT,
+    /** Service */
+    SERVICE,
     /** Timer */
     TIMER;
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2MessageTransportInstance.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2MessageTransportInstance.java
@@ -48,7 +48,7 @@ public class Ros2MessageTransportInstance extends CustomStateValue {
      * @param destinationSubscriptionHandle
      *            the destination subscription handle
      * @param sourcePublicationTimestamp
-     *            the source publication timestmap
+     *            the source publication timestamp
      * @param destinationTakeTimestamp
      *            the destination take timestamp
      */

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2Request.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2Request.java
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (c) 2024 Apex.AI, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.ros2.core.model.messages;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects.Gid;
+
+import com.google.common.base.Objects;
+
+/**
+ * Container for ROS 2 request info.
+ *
+ * This is used to match a request sent by a client to a request taken by a
+ * service.
+ *
+ * @author Christophe Bedard
+ */
+public class Ros2Request {
+
+    private final @NonNull Gid fClientGid;
+    private final long fSequenceNumber;
+
+    /**
+     * Constructor
+     *
+     * @param clientGid
+     *            the GID of the client sending the request
+     * @param sequenceNumber
+     *            the request sequence number
+     */
+    public Ros2Request(@NonNull Gid clientGid, long sequenceNumber) {
+        fClientGid = clientGid;
+        fSequenceNumber = sequenceNumber;
+    }
+
+    /**
+     * @return the GID of the client sending the request
+     */
+    public @NonNull Gid getClientGid() {
+        return fClientGid;
+    }
+
+    /**
+     * @return the request sequence number
+     */
+    public long getSequenceNumber() {
+        return fSequenceNumber;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(fClientGid, fSequenceNumber);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Ros2Request o = (Ros2Request) obj;
+        return o.fClientGid.equals(fClientGid) && o.fSequenceNumber == fSequenceNumber;
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return String.format("Ros2Request: clientGid=%d, sequenceNumber=%s", fClientGid.toString(), fSequenceNumber); //$NON-NLS-1$
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2Response.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/messages/Ros2Response.java
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (c) 2024 Apex.AI, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.ros2.core.model.messages;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.google.common.base.Objects;
+
+/**
+ * Container for ROS 2 response info.
+ *
+ * This is used to match a response sent by a service to a response taken by a
+ * client.
+ *
+ * @author Christophe Bedard
+ */
+public class Ros2Response {
+
+    private final @NonNull Ros2Request fRequestInfo;
+    private final long fSourceTimestamp;
+
+    /**
+     * Constructor
+     *
+     * @param requestInfo
+     *            the info of the request that this response is for
+     * @param sourceTimestamp
+     *            the source timestamp of the response
+     */
+    public Ros2Response(@NonNull Ros2Request requestInfo, long sourceTimestamp) {
+        fRequestInfo = requestInfo;
+        fSourceTimestamp = sourceTimestamp;
+    }
+
+    /**
+     * @return the info of the request that this response is for
+     */
+    public @NonNull Ros2Request getRequestInfo() {
+        return fRequestInfo;
+    }
+
+    /**
+     * @return the source timestamp of the response
+     */
+    public long getSourceTimestamp() {
+        return fSourceTimestamp;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(fRequestInfo, fSourceTimestamp);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Ros2Response o = (Ros2Response) obj;
+        return o.fRequestInfo.equals(fRequestInfo) && o.fSourceTimestamp == fSourceTimestamp;
+    }
+
+    @Override
+    public @NonNull String toString() {
+        return String.format("Ros2Response: requestInfo=[%s], sourceTimestamp=%s", fRequestInfo.toString(), fSourceTimestamp); //$NON-NLS-1$
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2CallbackType.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2CallbackType.java
@@ -24,6 +24,9 @@ public enum Ros2CallbackType {
     /**
      * Timer
      */
-    TIMER;
-    // TODO service, etc.
+    TIMER,
+    /**
+     * Service (i.e., service server)
+     */
+    SERVICE;
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2ClientObject.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2ClientObject.java
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (c) 2024 Apex.AI, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.datastore.core.serialization.ISafeByteBufferReader;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostInfo;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostProcess;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostProcessPointer;
+
+/**
+ * Container for ROS 2 client object (i.e., service client).
+ *
+ * @author Christophe Bedard
+ */
+public class Ros2ClientObject extends Ros2PubSubObject {
+
+    /** Custom type value ID for this object */
+    public static final byte CUSTOM_TYPE_ID = 75;
+    /** CustomStateValueFactory for this object */
+    @SuppressWarnings("restriction")
+    public static final @NonNull CustomStateValueFactory ROS2_CLIENT_OBJECT_VALUE_FACTORY = b -> Ros2ClientObject.read(b);
+
+    // We do not currently collect a DDS pointer for clients
+    private static final @NonNull HostProcessPointer HOST_PROCESS_POINTER_UNUSED = new HostProcessPointer(new HostProcess(new HostInfo(StringUtils.EMPTY, StringUtils.EMPTY), 0L), 0L);
+
+    /**
+     * Constructor
+     *
+     * @param clientHandle
+     *            the client handle
+     * @param rmwClientHandle
+     *            the rmw client handle
+     * @param nodeHandle
+     *            the node handle
+     * @param serviceName
+     *            the service name
+     * @param gid
+     *            the rmw GID
+     */
+    public Ros2ClientObject(@NonNull Ros2ObjectHandle clientHandle, @NonNull Ros2ObjectHandle rmwClientHandle, @NonNull String serviceName, @NonNull Ros2ObjectHandle nodeHandle, @NonNull Gid gid) {
+        super(clientHandle, rmwClientHandle, serviceName, nodeHandle, gid, HOST_PROCESS_POINTER_UNUSED);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Ros2ClientObject: %s", super.toString()); //$NON-NLS-1$
+    }
+
+    @Override
+    protected @NonNull Byte getCustomTypeId() {
+        return CUSTOM_TYPE_ID;
+    }
+
+    /**
+     * @param buffer
+     *            the buffer
+     * @return the value
+     */
+    public static @NonNull Ros2ClientObject read(ISafeByteBufferReader buffer) {
+        Ros2ObjectHandle clientHandle = Ros2ObjectHandle.read(buffer);
+        Ros2ObjectHandle rmwClientHandle = Ros2ObjectHandle.read(buffer);
+        String serviceName = buffer.getString();
+        Ros2ObjectHandle nodeHandle = Ros2ObjectHandle.read(buffer);
+        Gid gid = Gid.read(buffer);
+        // It's unused, but make sure to read the whole buffer
+        HostProcessPointer.read(buffer);
+        return new Ros2ClientObject(clientHandle, rmwClientHandle, serviceName, nodeHandle, gid);
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2ServiceObject.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/objects/Ros2ServiceObject.java
@@ -1,0 +1,103 @@
+/**********************************************************************
+ * Copyright (c) 2024 Apex.AI, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.ros2.core.model.objects;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.datastore.core.serialization.ISafeByteBufferReader;
+import org.eclipse.tracecompass.datastore.core.serialization.ISafeByteBufferWriter;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostInfo;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostProcess;
+import org.eclipse.tracecompass.incubator.internal.ros2.core.model.HostProcessPointer;
+
+/**
+ * Container for ROS 2 service object (i.e., service server).
+ *
+ * @author Christophe Bedard
+ */
+public class Ros2ServiceObject extends Ros2PubSubObject {
+
+    /** Custom type value ID for this object */
+    public static final byte CUSTOM_TYPE_ID = 76;
+    /** CustomStateValueFactory for this object */
+    @SuppressWarnings("restriction")
+    public static final @NonNull CustomStateValueFactory ROS2_SERVICE_OBJECT_VALUE_FACTORY = b -> Ros2ServiceObject.read(b);
+
+    // We do not currently collect a DDS pointer for services
+    private static final @NonNull HostProcessPointer HOST_PROCESS_POINTER_UNUSED = new HostProcessPointer(new HostProcess(new HostInfo(StringUtils.EMPTY, StringUtils.EMPTY), 0L), 0L);
+
+    private final @NonNull HostProcessPointer fCallback;
+    private final int fSerializedValueSize;
+
+    /**
+     * Constructor
+     *
+     * @param serviceHandle
+     *            the service handle
+     * @param rmwServiceHandle
+     *            the rmw service handle
+     * @param nodeHandle
+     *            the node handle
+     * @param serviceName
+     *            the service name
+     * @param callback
+     *            the corresponding callback object
+     */
+    public Ros2ServiceObject(@NonNull Ros2ObjectHandle serviceHandle, @NonNull Ros2ObjectHandle rmwServiceHandle, @NonNull String serviceName, @NonNull Ros2ObjectHandle nodeHandle, @NonNull HostProcessPointer callback) {
+        super(serviceHandle, rmwServiceHandle, serviceName, nodeHandle, new Gid(ArrayUtils.EMPTY_LONG_ARRAY), HOST_PROCESS_POINTER_UNUSED);
+        fCallback = callback;
+
+        int size = 0;
+        size += super.getSerializedValueSize();
+        size += fCallback.getSerializedValueSize();
+        fSerializedValueSize = size;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Ros2ServiceObject: %s", super.toString()); //$NON-NLS-1$
+    }
+
+    @Override
+    protected @NonNull Byte getCustomTypeId() {
+        return CUSTOM_TYPE_ID;
+    }
+
+    @Override
+    protected void serializeValue(@NonNull ISafeByteBufferWriter buffer) {
+        super.serializeValue(buffer);
+        fCallback.serializeValue(buffer);
+    }
+
+    @Override
+    protected int getSerializedValueSize() {
+        return fSerializedValueSize;
+    }
+
+    /**
+     * @param buffer
+     *            the buffer
+     * @return the value
+     */
+    public static @NonNull Ros2ServiceObject read(ISafeByteBufferReader buffer) {
+        Ros2ObjectHandle serviceHandle = Ros2ObjectHandle.read(buffer);
+        Ros2ObjectHandle rmwServiceHandle = Ros2ObjectHandle.read(buffer);
+        String serviceName = buffer.getString();
+        Ros2ObjectHandle nodeHandle = Ros2ObjectHandle.read(buffer);
+        // GID and HostProcessPointer are unused, but make sure to read the whole buffer
+        Gid.read(buffer);
+        HostProcessPointer.read(buffer);
+        HostProcessPointer callback = HostProcessPointer.read(buffer);
+        return new Ros2ServiceObject(serviceHandle, rmwServiceHandle, serviceName, nodeHandle, callback);
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/IRos2EventLayout.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/IRos2EventLayout.java
@@ -157,9 +157,34 @@ public interface IRos2EventLayout {
     String eventRclcppServiceCallbackAdded();
 
     /**
+     * <code>rmw_take_request</code>
+     */
+    String eventRmwTakeRequest();
+
+    /**
+     * <code>rmw_send_response</code>
+     */
+    String eventRmwSendResponse();
+
+    /**
+     * <code>rmw_client_init</code>
+     */
+    String eventRmwClientInit();
+
+    /**
      * <code>rcl_client_init</code>
      */
     String eventRclClientInit();
+
+    /**
+     * <code>rmw_send_request</code>
+     */
+    String eventRmwSendRequest();
+
+    /**
+     * <code>rmw_take_response</code>
+     */
+    String eventRmwTakeResponse();
 
     /**
      * <code>rcl_timer_init</code>
@@ -282,6 +307,10 @@ public interface IRos2EventLayout {
     String fieldServiceName();
     String fieldClientHandle();
     String fieldRmwClientHandle();
+    String fieldRequest();
+    String fieldClientGid();
+    String fieldSequenceNumber();
+    String fieldResponse();
     String fieldTimerHandle();
     String fieldPeriod();
     String fieldSymbol();

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/Ros2RollingEventLayout.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/Ros2RollingEventLayout.java
@@ -39,7 +39,12 @@ public class Ros2RollingEventLayout implements IRos2EventLayout {
     private static final String RCLCPP_TAKE = "rclcpp_take";
     private static final String RCL_SERVICE_INIT = "rcl_service_init";
     private static final String RCLCPP_SERVICE_CALLBACK_ADDED = "rclcpp_service_callback_added";
+    private static final String RMW_TAKE_REQUEST = "rmw_take_request";
+    private static final String RMW_SEND_RESPONSE = "rmw_send_response";
+    private static final String RMW_CLIENT_INIT = "rmw_client_init";
     private static final String RCL_CLIENT_INIT = "rcl_client_init";
+    private static final String RMW_SEND_REQUEST = "rmw_send_request";
+    private static final String RMW_TAKE_RESPONSE = "rmw_take_response";
     private static final String RCL_TIMER_INIT = "rcl_timer_init";
     private static final String RCLCPP_TIMER_CALLBACK_ADDED = "rclcpp_timer_callback_added";
     private static final String RCLCPP_TIMER_LINK_NODE = "rclcpp_timer_link_node";
@@ -85,6 +90,10 @@ public class Ros2RollingEventLayout implements IRos2EventLayout {
     private static final String SERVICE_NAME = "service_name";
     private static final String CLIENT_HANDLE = "client_handle";
     private static final String RMW_CLIENT_HANDLE = "rmw_client_handle";
+    private static final String CLIENT_GID = "client_gid";
+    private static final String REQUEST = "request";
+    private static final String SEQUENCE_NUMBER = "sequence_number";
+    private static final String RESPONSE = "response";
     private static final String TIMER_HANDLE = "timer_handle";
     private static final String PERIOD = "period";
     private static final String SYMBOL = "symbol";
@@ -246,11 +255,46 @@ public class Ros2RollingEventLayout implements IRos2EventLayout {
         return getProviderName() + RCLCPP_SERVICE_CALLBACK_ADDED;
     }
 
+    // rmw_take_request
+
+    @Override
+    public String eventRmwTakeRequest() {
+        return getProviderName() + RMW_TAKE_REQUEST;
+    }
+
+    // rmw_send_response
+
+    @Override
+    public String eventRmwSendResponse() {
+        return getProviderName() + RMW_SEND_RESPONSE;
+    }
+
+    // rmw_client_init
+
+    @Override
+    public String eventRmwClientInit() {
+        return getProviderName() + RMW_CLIENT_INIT;
+    }
+
     // rcl_client_init
 
     @Override
     public String eventRclClientInit() {
         return getProviderName() + RCL_CLIENT_INIT;
+    }
+
+    // rmw_send_request
+
+    @Override
+    public String eventRmwSendRequest() {
+        return getProviderName() + RMW_SEND_REQUEST;
+    }
+
+    // rmw_take_response
+
+    @Override
+    public String eventRmwTakeResponse() {
+        return getProviderName() + RMW_TAKE_RESPONSE;
     }
 
     // rcl_timer_init
@@ -500,6 +544,26 @@ public class Ros2RollingEventLayout implements IRos2EventLayout {
     @Override
     public String fieldRmwClientHandle() {
         return RMW_CLIENT_HANDLE;
+    }
+
+    @Override
+    public String fieldRequest() {
+        return REQUEST;
+    }
+
+    @Override
+    public String fieldClientGid() {
+        return CLIENT_GID;
+    }
+
+    @Override
+    public String fieldSequenceNumber() {
+        return SEQUENCE_NUMBER;
+    }
+
+    @Override
+    public String fieldResponse() {
+        return RESPONSE;
     }
 
     @Override

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.ui/src/org/eclipse/tracecompass/incubator/internal/ros2/ui/views/Ros2ObjectTreeLabelProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.ui/src/org/eclipse/tracecompass/incubator/internal/ros2/ui/views/Ros2ObjectTreeLabelProvider.java
@@ -37,6 +37,8 @@ public class Ros2ObjectTreeLabelProvider {
     private static final String COLUMN_TEXT_PREFIX_NODE = "🔲 "; //$NON-NLS-1$
     private static final String COLUMN_TEXT_PREFIX_PUBLISHER = "↗️ "; //$NON-NLS-1$
     private static final String COLUMN_TEXT_PREFIX_SUBSCRIPTION = "↘️ "; //$NON-NLS-1$
+    private static final String COLUMN_TEXT_PREFIX_CLIENT = "S↗️ "; //$NON-NLS-1$
+    private static final String COLUMN_TEXT_PREFIX_SERVICE = "S↘️ "; //$NON-NLS-1$
     private static final String COLUMN_TEXT_PREFIX_TIMER = "⏳ "; //$NON-NLS-1$
 
     private Ros2ObjectTreeLabelProvider() {
@@ -97,6 +99,10 @@ public class Ros2ObjectTreeLabelProvider {
             return COLUMN_TEXT_PREFIX_PUBLISHER + entry.getName();
         } else if (Ros2ObjectTimeGraphEntryModelType.SUBSCRIPTION == type) {
             return COLUMN_TEXT_PREFIX_SUBSCRIPTION + entry.getName();
+        } else if (Ros2ObjectTimeGraphEntryModelType.CLIENT == type) {
+            return COLUMN_TEXT_PREFIX_CLIENT + entry.getName();
+        } else if (Ros2ObjectTimeGraphEntryModelType.SERVICE == type) {
+            return COLUMN_TEXT_PREFIX_SERVICE + entry.getName();
         } else if (Ros2ObjectTimeGraphEntryModelType.TIMER == type) {
             return COLUMN_TEXT_PREFIX_TIMER + entry.getName();
         }


### PR DESCRIPTION
This adds support for the new client/service (i.e., RPC) instrumentation in ROS 2, see https://github.com/ros2/ros2_tracing/pull/145.

1. In the objects analysis, create client and service objects
2. In the messages analysis, create the following instances:
    1. Request publication
    2. Request take and callback
    3. Response publication
    4. Response take
    5. Message transport for requests and responses
3. In the messages dataprovider, display the above instances

There is one limitation. Normal message publications and message takes have instrumentation that provides a "start time." For example, for message publications, the `ros2:rclcpp_publish` tracepoint is the start and the `ros2:rmw_publish` tracepoint is the end of a message publication. This allows us to attribute a duration to the publication and therefore display a time graph state. However, we only have a single tracepoint for client/service-related publication/take instances, so we do not have any duration data. For now, just hardcode a 5000 ns duration so that time graph states are visible enough.

---

Example:  
![Screenshot from 2024-11-24 11-53-36](https://github.com/user-attachments/assets/add8a48d-6fc3-4124-a61c-ba065a9cf171)  
(trace: [2024-11-23__test_tracetools__test_service_pingpong__service-e2e.zip](https://github.com/user-attachments/files/17895029/2024-11-23__test_tracetools__test_service_pingpong__service-e2e.zip))

Clients (S↗️) and services (S↘️) are displayed under nodes (🔲) on the left. Chronological explanation:

1. The `/ping` client under the `/test_service_ping` node sends a request (short-ish time graph state from which the outgoing arrow starts)
2. The `/ping` service under the `/test_service_pong` node receives (takes) the request (thinner time graph state that the incoming arrow points to, right before the long time graph state)
3. The `/ping` service calls executes a callback for the request (long time graph state)
4. The `/ping` service sends a response inside the request callback (time at which the outgoing arrow starts)
5. The `/ping` client receives (takes) the request (thinner time graph state that the incoming arrow points to)