### PR TITLE
releng: Upgrade target to dependencies of 2024-12 (Eclipse 4.34) release

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="79">
+<target name="tracecompass-incubator-master" sequenceNumber="80">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
@@ -36,9 +36,10 @@
 <unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0"/>
 <unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations.source" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
-<unit id="com.google.guava" version="33.3.0.jre"/>
+<unit id="com.google.guava" version="33.3.1.jre"/>
 <unit id="com.sun.xml.bind.jaxb-osgi" version="2.3.9"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
+<unit id="jakarta.annotation-api" version="1.3.5"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
 <unit id="jakarta.inject.jakarta.inject-api" version="1.0.5"/>
 <unit id="jakarta.servlet.jsp-api" version="3.1.1"/>
@@ -64,23 +65,24 @@
 <unit id="org.glassfish.hk2.locator.source" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils.source" version="2.6.1"/>
-<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server" version="2.44.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.44.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.44.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.44.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.44.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.44.0"/>
+<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server" version="2.45.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.45.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.45.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.45.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.45.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.45.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.33.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -100,22 +102,25 @@
 <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.test.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
+<unit id="org.eclipse.jdt.core" version="0.0.0"/>
+<unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
 <unit id="org.eclipse.swt.tools.spies" version="0.0.0"/>
 <unit id="org.eclipse.ui.trace" version="0.0.0"/>
 <unit id="org.eclipse.ui.views.log" version="0.0.0"/>
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.33/R-4.33-202409030240/"/>
+<unit id="org.eclipse.osgi.services" version="0.0.0"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.34/R-4.34-202411201800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.35.0/R-3.35.0-20240825085431/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.36.0/R-3.36.0-20241110095156/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.39.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.40.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Trace Compass 10.2.0

Requires https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/194 to be merged and Trace Compass nightly update site build with it. 

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>