### PR TITLE
Add import package org.glassfish.jersey to rest.core.tests

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/META-INF/MANIFEST.MF
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/META-INF/MANIFEST.MF
@@ -44,5 +44,6 @@ Import-Package: com.fasterxml.jackson.annotation,
  org.eclipse.tracecompass.testtraces.ctf,
  org.eclipse.tracecompass.tmf.ctf.core.tests.shared,
  org.eclipse.tracecompass.tmf.ctf.core.trace,
+ org.glassfish.jersey,
  org.glassfish.jersey.server
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests


### PR DESCRIPTION
With this the interface ApplicationSupplier that the class org.glassfish.jersey.server.ResourceConfig implements can be resolved when running in the Eclipse development environment.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>