### PR TITLE
Add support for data provider capabilities in server and InAndOut analysis

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
@@ -33,6 +33,7 @@ import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
 import org.eclipse.tracecompass.tmf.core.signal.TmfSignalManager;
@@ -72,6 +73,7 @@ public class InAndOutDataProviderFactoryTest {
             .setName(EXPECTED_CONFIGURATOR_NAME)
             .setDescription(EXPECTED_CONFIGURATOR_DESCRIPTION)
             .setProviderType(ProviderType.NONE)
+            .setCapabilities(new DataProviderCapabilities.Builder().setCanCreate(true).build())
             .build();
 
     private static InAndOutDataProviderFactory sfFixture = new InAndOutDataProviderFactory();
@@ -166,6 +168,7 @@ public class InAndOutDataProviderFactoryTest {
         assertEquals(CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION, descriptor.getDescription());
         assertEquals(ProviderType.NONE, descriptor.getType());
         assertEquals(EXPECTED_FACTORY_ID, descriptor.getParentId());
+        assertEquals(new DataProviderCapabilities.Builder().setCanDelete(true).build(), descriptor.getCapabilities());
         ITmfConfiguration config = descriptor.getConfiguration();
         assertNotNull(config);
 

--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Ericsson
+ * Copyright (c) 2024, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -37,6 +37,7 @@ import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfConfigurationException;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataProvider;
@@ -98,6 +99,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
             .setName(CONFIGURATOR_NAME)
             .setDescription(CONFIGURATOR_DESCRIPTION)
             .setProviderType(ProviderType.NONE)
+            .setCapabilities(new DataProviderCapabilities.Builder().setCanCreate(true).build())
             .build();
 
     /**
@@ -264,6 +266,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
                 .setDescription(NLS.bind(CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION, config.getName()))
                 .setProviderType(ProviderType.NONE)
                 .setConfiguration(config)
+                .setCapabilities(new DataProviderCapabilities.Builder().setCanDelete(true).build())
                 .build();
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/DataProviderDescriptorSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/DataProviderDescriptorSerializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -14,7 +14,9 @@ package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.cor
 import java.io.IOException;
 
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderCapabilities;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderCapabilities;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -54,6 +56,13 @@ public class DataProviderDescriptorSerializer extends StdSerializer<IDataProvide
         ITmfConfiguration config = value.getConfiguration();
         if (config != null) {
             gen.writeObjectField("configuration", config); //$NON-NLS-1$
+        }
+        IDataProviderCapabilities cap = value.getCapabilities();
+        if (cap != DataProviderCapabilities.NULL_INSTANCE) {
+            gen.writeObjectFieldStart("capabilities"); //$NON-NLS-1$
+            gen.writeBooleanField("canCreate", cap.canCreate()); //$NON-NLS-1$
+            gen.writeBooleanField("canDelete", cap.canDelete()); //$NON-NLS-1$
+            gen.writeEndObject();
         }
         gen.writeEndObject();
     }


### PR DESCRIPTION
- trace-server: serialize IDataProviderCapabilities in descriptors
- Set Capabilities in relevant descriptors of InAndOutDataProviderFactory

Requires https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/198 to be integrated.

see also https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>
