### PR TITLE
[trace server] update link to Jetty SSL setup doc

### DIFF
--- a/trace-server/README.md
+++ b/trace-server/README.md
@@ -39,7 +39,7 @@ OpenAPI REST specification:
 
 The trace server can be run using SSL certificates.
 Jetty requires the certificate and private key to be in a keystore.
-Follow the instructions to [configure SSL on jetty](https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html).
+Follow the instructions to [configure SSL on jetty](https://jetty.org/docs/jetty/12/operations-guide/keystore/index.html).
 
 Then, you can edit the `tracecompass-server.ini` file to pass the keystore data and SSL port as parameters after the `-vmargs` line.
 For example, here is an excerpt of the file:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
This PR updates the trace server README link to the Jetty SSL setup documentation.

The existing link \[1\], to the Jetty documentation for the SSL setup, no longer resolves to the correct page, instead leading to a root documentation page on jetty.org, where one needs to pick the Jetty version to get to the documentation, and then search for the relevant SSL-related page.

Under there, I found what seems to be the relevant link for SSL documentation [2], for Jetty version 12 (latest as of now).

\[1\]: https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html
\[2\]: https://jetty.org/docs/jetty/12/operations-guide/keystore/index.html

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

N/A

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
