### PR TITLE
swagger: Add DataProviderCapabilities to swagger documentation

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Ericsson
+ * Copyright (c) 2021, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -56,12 +56,19 @@ public interface DataProvider {
     /**
      * @return optional parent Id
      */
-    @Schema(required = false, description = "Optional parent Id for grouping purposes for example of derived data providers.")
+    @Schema(description = "Optional parent Id for grouping purposes for example of derived data providers.")
     String getParentId();
 
     /**
      * @return the input configuration used to create this data provider.
      */
-    @Schema(required = false, description = "Optional input configuration used to create this derived data provider.")
+    @Schema(description = "Optional input configuration used to create this derived data provider.")
     Configuration getConfiguration();
+
+    /**
+     * @return optional output capabilities. If absent, all capabilities are 'false'.
+     */
+    @Schema(description = "Optional output capabilities, such as 'canCreate' and 'canDelete'. If absent, all capabilities are 'false'.")
+    OutputCapabilities getCapabilities();
+
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputCapabilities.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputCapabilities.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+public interface OutputCapabilities {
+
+    /**
+     * @return whether this output (data provider) can create derived outputs (data providers). 'false' if absent.
+     */
+    @JsonProperty("canCreate")
+    @Schema(description = "Optional, whether this output (data provider) can create derived outputs (data providers). 'false' if absent.")
+    boolean canCreate();
+
+    /**
+     * @return whether this output (data provider) can be deleted. 'false' if absent.
+     */
+    @Schema(description = "Optional, whether this output (data provider) can be deleted. 'false' if absent.")
+    @JsonProperty("canDelete")
+    boolean canDelete();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

This PR adds the DataProviderCapabilities API to the swagger documentation. 

See ADR: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/1158

### How to test

Run trace-server and create the API documentation as described here https://github.com/eclipse-cdt-cloud/trace-server-protocol?tab=readme-ov-file#generate-the-api.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>