### PR TITLE
releng: upgrade github actions to v4 in the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: 
+    branches:
       - master
       - stable-*
   pull_request:
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -33,10 +33,10 @@ jobs:
     - name: Build with Maven
       uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
       with:
-       run: >- 
+       run: >-
         mvn -B clean install
     - name: Upload logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: Build logs
@@ -44,7 +44,7 @@ jobs:
           */*tests/screenshots/*.jpeg
           */*tests/target/work/data/.metadata/.log
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: Test results


### PR DESCRIPTION
GitHub Actions deprecated v3 of actions/upload-artifact and actions/download-artifact. This PR upgrades github actions to v4 to ensure compatibility.