### PR TITLE
releng: Bundle java runtime in Trace Compass RCP and Trace Server RCP

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-e4.34" sequenceNumber="1">
+<target name="tracecompass-incubator-e4.34" sequenceNumber="2">
 <locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
+<unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
+</location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tm.terminal.control" version="0.0.0"/>

--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="80">
+<target name="tracecompass-incubator-master" sequenceNumber="81">
 <locations>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
+<unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
+</location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.cdt.gnu.dsf.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tm.terminal.control" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <tycho.scmUrl>scm:git:git://git.eclipse.org/gitroot/tracecompass.incubator/org.eclipse.tracecompass.incubator.git</tycho.scmUrl>
     <cbi-plugins.version>1.4.2</cbi-plugins.version>
     <target-platform>tracecompass-incubator-master</target-platform>
-    <help-docs-eclipserun-repo>http://download.eclipse.org/eclipse/updates/4.20</help-docs-eclipserun-repo>
+    <help-docs-eclipserun-repo>http://download.eclipse.org/eclipse/updates/4.23</help-docs-eclipserun-repo>
 
     <rcptt-version>2.5.4</rcptt-version>
     <!-- Disable GTK3 because it's not quite usable yet and it can make the tests hang (bug in IcedTea http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1736) -->
@@ -385,7 +385,7 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <executionEnvironment>JavaSE-${jdk.version}</executionEnvironment>
+          <executionEnvironment>org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped-${jdk.version}</executionEnvironment>
           <environments>
             <environment>
                 <os>win32</os>

--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product
@@ -172,6 +172,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.scripting" installMode="root"/>
       <feature id="org.eclipse.tracecompass.incubator.scripting.javascript" installMode="root"/>
       <feature id="org.eclipse.tracecompass.incubator.scripting.python" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
    </features>
 
    <configurations>

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
@@ -171,6 +171,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.jetty.servlet-api"/>
       <plugin id="org.eclipse.jetty.session"/>
       <plugin id="org.eclipse.jetty.util"/>
+      <plugin id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped"/>
       <plugin id="org.eclipse.ltk.core.refactoring"/>
       <plugin id="org.eclipse.orbit.xml-apis-ext"/>
       <plugin id="org.eclipse.osgi"/>
@@ -191,9 +192,9 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.incubator.analysis.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.ftrace.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.gpu.core"/>
-      <plugin id="org.eclipse.tracecompass.incubator.rocm.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.inandout.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.opentracing.core"/>
+      <plugin id="org.eclipse.tracecompass.incubator.rocm.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.traceevent.core"/>
       <plugin id="org.eclipse.tracecompass.jsontrace.core"/>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Update target files to include [JustJ JREs]( https://eclipse.dev/justj/) with respective version for that release. Use latest available JRE version for respective major version.

This will make it easier for end-users to use Trace Compass because Java doesn't need to be installed separately and it will include the correct, required version.

Notes:

- The stripped version of the JRE is used with debug information stripped and excluding the src.jar with sources used only for debugging. This minimizes the size of the JRE package because it's less than 1/2 the size of the corresponding full version. If you'd like to debug the RCP (e.g. using remote debugging), use a separated JVM as described below.
- To run the RCP with a different JVM (e.g. installed on user's laptop), open the tracecompass.ini/tracecompass-server.ini file and modify the path settings for `-vm`. Or remove it completely then the default JRE of the computer is used.

Use a newer update site for `help-docs-eclipserun-repo` property in main pom.xml to allow builds be successful when building with Java 21.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test
Build and run the Trace Compass RCP. Check in configuration (`Help -> About... -> Installation Details -> Configuration`) the bundled JRE is used.

To check the Trace Compass server, open the `tracecompass-server.ini` file and verify that `-vm` points to the included JRE.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
