### PR TITLE
Use trace-event-logger lib

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.executioncomparison.core/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.executioncomparison.core/META-INF/MANIFEST.MF
@@ -30,4 +30,5 @@ Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.cache,
  com.google.common.collect,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analyses/org.eclipse.tracecompass.incubator.executioncomparison.core/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/core/DifferentialSeqCallGraphAnalysis.java
+++ b/analyses/org.eclipse.tracecompass.incubator.executioncomparison.core/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/core/DifferentialSeqCallGraphAnalysis.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 École Polytechnique de Montréal, Ericsson
+ * Copyright (c) 2024, 2025 École Polytechnique de Montréal, Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -38,7 +38,6 @@ import org.eclipse.tracecompass.analysis.profiling.core.tree.IWeightedTreeProvid
 import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTree;
 import org.eclipse.tracecompass.analysis.profiling.core.tree.WeightedTreeSet;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.diff.DifferentialWeightedTree;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.diff.DifferentialWeightedTreeProvider;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.diff.WeightedTreeUtils;
@@ -53,6 +52,7 @@ import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.google.common.collect.Iterables;
 

--- a/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/META-INF/MANIFEST.MF
@@ -20,4 +20,5 @@ Require-Bundle: org.eclipse.ui,
 Export-Package: org.eclipse.tracecompass.incubator.internal.executioncomparison.ui;x-internal:=true
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.executioncomparison.ui
 Import-Package: com.google.common.collect,
- org.eclipse.swtchart
+ org.eclipse.swtchart,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/ui/DifferentialFlameGraphView.java
+++ b/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/ui/DifferentialFlameGraphView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 École Polytechnique de Montréal, Ericsson
+ * Copyright (c) 2024, 2025 École Polytechnique de Montréal, Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -50,9 +50,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.tracecompass.analysis.profiling.core.callgraph.ICallGraphProvider2;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.diff.DifferentialWeightedTreeProvider;
 import org.eclipse.tracecompass.incubator.internal.executioncomparison.core.DifferentialSeqCallGraphAnalysis;
 import org.eclipse.tracecompass.internal.analysis.profiling.core.flamegraph.FlameGraphDataProvider;
@@ -99,6 +96,9 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sampling;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.TimeGraphControl;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils.TimeFormat;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.progress.IWorkbenchSiteProgressService;

--- a/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/ui/ExecutionComparisonView.java
+++ b/analyses/org.eclipse.tracecompass.incubator.executioncomparison.ui/src/org/eclipse/tracecompass/incubator/internal/executioncomparison/ui/ExecutionComparisonView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 École Polytechnique de Montréal, Ericsson
+ * Copyright (c) 2024, 2025 École Polytechnique de Montréal, Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -57,7 +57,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Sash;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.incubator.internal.executioncomparison.core.TmfCheckboxChangedSignal;
 import org.eclipse.tracecompass.incubator.internal.executioncomparison.core.TmfComparisonFilteringUpdatedSignal;
 import org.eclipse.tracecompass.internal.tmf.ui.viewers.eventdensity.EventDensityTreeViewer;
@@ -88,6 +87,7 @@ import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfFilteredXYCh
 import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
 import org.eclipse.tracecompass.tmf.ui.views.ManyEntriesSelectedDialogPreCheckedListener;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.dialogs.TriStateFilteredCheckboxTree;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.contexts.IContextActivation;

--- a/analyses/org.eclipse.tracecompass.incubator.kernel.core/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.kernel.core/META-INF/MANIFEST.MF
@@ -29,4 +29,5 @@ Export-Package: org.eclipse.tracecompass.incubator.internal.kernel.core;x-friend
  org.eclipse.tracecompass.incubator.internal.kernel.core.swslatency;x-internal:=true
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.kernel.core
 Import-Package: com.google.common.collect,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analyses/org.eclipse.tracecompass.incubator.kernel.core/src/org/eclipse/tracecompass/incubator/internal/kernel/core/io/IoAccessDataProvider.java
+++ b/analyses/org.eclipse.tracecompass.incubator.kernel.core/src/org/eclipse/tracecompass/incubator/internal/kernel/core/io/IoAccessDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Ericsson and others
+ * Copyright (c) 2018, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -30,8 +30,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.incubator.internal.kernel.core.Activator;
 import org.eclipse.tracecompass.internal.analysis.os.linux.core.inputoutput.IODataPalette;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
@@ -60,6 +58,8 @@ import org.eclipse.tracecompass.tmf.core.response.ITmfResponse.Status;
 import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;

--- a/analyses/org.eclipse.tracecompass.incubator.tmf.ui.multiview.ui/META-INF/MANIFEST.MF
+++ b/analyses/org.eclipse.tracecompass.incubator.tmf.ui.multiview.ui/META-INF/MANIFEST.MF
@@ -26,4 +26,5 @@ Import-Package: com.google.common.base,
  com.google.common.collect,
  org.eclipse.nebula.widgets.opal.commons,
  org.eclipse.nebula.widgets.opal.duallist,
- org.eclipse.swtchart
+ org.eclipse.swtchart,
+ org.eclipse.tracecompass.traceeventlogger

--- a/analyses/org.eclipse.tracecompass.incubator.tmf.ui.multiview.ui/src/org/eclipse/tracecompass/incubator/internal/tmf/ui/multiview/ui/view/timegraph/AbstractTimeGraphMultiViewer.java
+++ b/analyses/org.eclipse.tracecompass.incubator.tmf.ui.multiview.ui/src/org/eclipse/tracecompass/incubator/internal/tmf/ui/multiview/ui/view/timegraph/AbstractTimeGraphMultiViewer.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 Draeger, Auriga
+ * Copyright (c) 2020, 2025 Draeger, Auriga and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -80,9 +80,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.incubator.internal.tmf.ui.multiview.ui.view.IMultiViewer;
 import org.eclipse.tracecompass.incubator.internal.tmf.ui.multiview.ui.view.MultiView;
 import org.eclipse.tracecompass.internal.provisional.tmf.core.model.filter.parser.FilterCu;
@@ -138,6 +135,10 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sampling;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.TimeGraphControl;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils.TimeFormat;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 import org.eclipse.ui.IPartListener;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IViewSite;
@@ -1323,7 +1324,7 @@ public abstract class AbstractTimeGraphMultiViewer extends TmfViewer implements 
         }
         fTrace = trace;
 
-        TraceCompassLogUtils.traceInstant(LOGGER, Level.FINE, "MultiTimeGraphViewer:LoadingTrace", "trace", trace.getName(), "viewerId", getViewerId()); //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
+        LogUtils.traceInstant(LOGGER, Level.FINE, "MultiTimeGraphViewer:LoadingTrace", "trace", trace.getName(), "viewerId", getViewerId()); //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
 
         restoreViewContext();
         fEditorFile = TmfTraceManager.getInstance().getTraceEditorFile(trace);
@@ -1885,7 +1886,7 @@ public abstract class AbstractTimeGraphMultiViewer extends TmfViewer implements 
         public void doRun() {
             Sampling sampling = new Sampling(getZoomStartTime(), getZoomEndTime(), getResolution());
             boolean isFilterActive = !getRegexes().values().isEmpty();
-            try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates")) { //$NON-NLS-1$
+            try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStates")) { //$NON-NLS-1$
                 boolean isFilterCleared = !isFilterActive && getTimeGraphViewer().isTimeEventFilterActive();
                 getTimeGraphViewer().setTimeEventFilterApplied(isFilterActive);
 
@@ -1896,7 +1897,7 @@ public abstract class AbstractTimeGraphMultiViewer extends TmfViewer implements 
                 zoomEntries(incorrectSample, getZoomStartTime(), getZoomEndTime(), getResolution(), getMonitor());
             }
             List<ILinkEvent> computedLinks;
-            try (TraceCompassLogUtils.ScopeLog linkLog = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
+            try (ScopeLog linkLog = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingLinks")) { //$NON-NLS-1$
                 /* Refresh the arrows when zooming */
                 computedLinks = getLinkList(getZoomStartTime(), getZoomEndTime(), getResolution(), getMonitor());
                 TimeEventFilterDialog filterDialog = getTimeEventFilterDialog();
@@ -1910,7 +1911,7 @@ public abstract class AbstractTimeGraphMultiViewer extends TmfViewer implements 
             }
             List<ILinkEvent> links = computedLinks;
             /* Refresh the viewer-specific markers when zooming */
-            try (TraceCompassLogUtils.ScopeLog markerLoglog = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
+            try (ScopeLog markerLoglog = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingMarkers")) { //$NON-NLS-1$
                 List<IMarkerEvent> markers = new ArrayList<>(getViewerMarkerList(getZoomStartTime(), getZoomEndTime(), getResolution(), getMonitor()));
                 /* Refresh the trace-specific markers when zooming */
                 markers.addAll(getTraceMarkerList(getZoomStartTime(), getZoomEndTime(), getResolution(), getMonitor()));
@@ -1930,7 +1931,7 @@ public abstract class AbstractTimeGraphMultiViewer extends TmfViewer implements 
 
             if (isFilterActive && Thread.currentThread() == fZoomThread) {
                 /* Do a full filter search as a second pass */
-                try (TraceCompassLogUtils.ScopeLog log = new TraceCompassLogUtils.ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStatesFullSearch")) { //$NON-NLS-1$
+                try (ScopeLog log = new ScopeLog(LOGGER, Level.FINER, "ZoomThread:GettingStatesFullSearch")) { //$NON-NLS-1$
                     for (TimeGraphEntry entry : fEntries) {
                         if (getMonitor().isCanceled()) {
                             return;

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.core/META-INF/MANIFEST.MF
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.core/META-INF/MANIFEST.MF
@@ -44,5 +44,6 @@ Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.cache,
  com.google.common.collect,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.callstack.core

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.core/src/org/eclipse/tracecompass/incubator/internal/callstack/core/flamegraph/FlameGraphDataProvider.java
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.core/src/org/eclipse/tracecompass/incubator/internal/callstack/core/flamegraph/FlameGraphDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 École Polytechnique de Montréal
+ * Copyright (c) 2019, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -36,8 +36,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.timing.core.statistics.IStatistics;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.datastore.core.serialization.ISafeByteBufferWriter;
 import org.eclipse.tracecompass.incubator.analysis.core.model.IHostModel;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.AllGroupDescriptor;
@@ -80,6 +78,8 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestamp;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.core/src/org/eclipse/tracecompass/incubator/internal/callstack/core/instrumented/provider/FlameChartDataProvider.java
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.core/src/org/eclipse/tracecompass/incubator/internal/callstack/core/instrumented/provider/FlameChartDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 École Polytechnique de Montréal
+ * Copyright (c) 2018, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -36,8 +36,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.os.linux.core.model.HostThread;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.incubator.callstack.core.base.EdgeStateValue;
 import org.eclipse.tracecompass.incubator.callstack.core.base.ICallStackElement;
 import org.eclipse.tracecompass.incubator.callstack.core.flamechart.CallStack;
@@ -84,6 +82,8 @@ import org.eclipse.tracecompass.tmf.core.symbols.SymbolProviderUtils;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.util.Pair;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.ui/META-INF/MANIFEST.MF
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.ui/META-INF/MANIFEST.MF
@@ -40,5 +40,6 @@ Import-Package: com.google.common.annotations,
  com.google.common.base,
  com.google.common.cache,
  com.google.common.collect,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.tracecompass.traceeventlogger
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.callstack.ui

--- a/callstack/org.eclipse.tracecompass.incubator.callstack.ui/src/org/eclipse/tracecompass/incubator/internal/callstack/ui/flamegraph/FlameGraphView.java
+++ b/callstack/org.eclipse.tracecompass.incubator.callstack.ui/src/org/eclipse/tracecompass/incubator/internal/callstack/ui/flamegraph/FlameGraphView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Ericsson
+ * Copyright (c) 2016, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -70,8 +70,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.tracecompass.common.core.NonNullUtils;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.AllGroupDescriptor;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.IWeightedTreeGroupDescriptor;
 import org.eclipse.tracecompass.incubator.analysis.core.weighted.tree.IWeightedTreeProvider;
@@ -127,6 +125,8 @@ import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.model.TimeGraphEntry.Sampling;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.TimeGraphControl;
 import org.eclipse.tracecompass.tmf.ui.widgets.timegraph.widgets.Utils.TimeFormat;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchActionConstants;

--- a/common/org.eclipse.tracecompass.incubator.releng-site/category.xml
+++ b/common/org.eclipse.tracecompass.incubator.releng-site/category.xml
@@ -95,6 +95,7 @@
    <bundle id="org.eclipse.nebula.widgets.opal.commons"/>
    <bundle id="org.eclipse.nebula.widgets.opal.duallist"/>
    <bundle id="org.eclipse.osgi.services"/>
+   <bundle id="org.eclipse.tracecompass.trace-event-logger"/>
    <bundle id="org.eclipse.wst.jsdt.core"/>
    <bundle id="org.eclipse.wst.jsdt.debug.core"/>
    <bundle id="org.eclipse.wst.jsdt.debug.ui"/>

--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-e4.34" sequenceNumber="2">
+<target name="tracecompass-incubator-e4.34" sequenceNumber="3">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -238,6 +238,16 @@
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2</artifactId>
 				<version>2.2.19</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.eclipse.tracecompass</groupId>
+				<artifactId>trace-event-logger</artifactId>
+				<version>0.3.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="81">
+<target name="tracecompass-incubator-master" sequenceNumber="82">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -238,6 +238,16 @@
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2</artifactId>
 				<version>2.2.19</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.eclipse.tracecompass</groupId>
+				<artifactId>trace-event-logger</artifactId>
+				<version>0.3.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/rcp/org.eclipse.tracecompass.incubator.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp/feature.xml
@@ -185,4 +185,8 @@
          id="org.eclipse.osgi.services"
          version="0.0.0"/>
 
+   <plugin
+         id="org.eclipse.tracecompass.trace-event-logger"
+         version="0.0.0"/>
+
 </feature>

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/META-INF/MANIFEST.MF
@@ -66,6 +66,7 @@ Import-Package: com.fasterxml.jackson.module.jaxb,
  org.eclipse.tracecompass.internal.analysis.timing.core.event.matching,
  org.eclipse.tracecompass.internal.tmf.analysis.xml.core.module,
  org.eclipse.tracecompass.tmf.analysis.xml.core.module,
+ org.eclipse.tracecompass.traceeventlogger,
  org.glassfish.jersey.inject.hk2,
  org.glassfish.jersey.servlet
 Bundle-ClassPath: .

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Ericsson
+ * Copyright (c) 2017, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -105,8 +105,6 @@ import javax.ws.rs.core.Response.Status;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.FlowScopeLogBuilder;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.AnnotationCategoriesResponse;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.AnnotationResponse;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.AnnotationsQueryParameters;
@@ -180,6 +178,8 @@ import org.eclipse.tracecompass.tmf.core.response.TmfModelResponse;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 import org.eclipse.tracecompass.tmf.core.trace.experiment.TmfExperiment;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLog;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.FlowScopeLogBuilder;
 import org.w3c.dom.Element;
 
 import com.google.common.collect.ImmutableList;

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TimeGraphArrowSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TimeGraphArrowSerializer.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -17,8 +17,8 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.ITimeGraphArrow;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TimeGraphRowModelSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TimeGraphRowModelSerializer.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -16,8 +16,8 @@ import java.util.logging.Logger;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.tracecompass.common.core.log.TraceCompassLog;
-import org.eclipse.tracecompass.common.core.log.TraceCompassLogUtils.ScopeLog;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphRowModel;
+import org.eclipse.tracecompass.traceeventlogger.LogUtils.ScopeLog;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy/traceserver.product
@@ -195,6 +195,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.tmf.core"/>
       <plugin id="org.eclipse.tracecompass.tmf.ctf.core"/>
       <plugin id="org.eclipse.tracecompass.tmf.filter.parser"/>
+      <plugin id="org.eclipse.tracecompass.trace-event-logger"/>
       <plugin id="org.glassfish.hk2.api"/>
       <plugin id="org.glassfish.hk2.external.jakarta.inject"/>
       <plugin id="org.glassfish.hk2.locator"/>

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
@@ -209,6 +209,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.tmf.core"/>
       <plugin id="org.eclipse.tracecompass.tmf.ctf.core"/>
       <plugin id="org.eclipse.tracecompass.tmf.filter.parser"/>
+      <plugin id="org.eclipse.tracecompass.trace-event-logger"/>
       <plugin id="org.glassfish.hk2.api"/>
       <plugin id="org.glassfish.hk2.locator"/>
       <plugin id="org.glassfish.hk2.osgi-resource-locator"/>


### PR DESCRIPTION
### What it does

Replace all use of TraceCompassLogUtils with LogUtils from the trace-event-logger library.

Update all targets to include the trace-event-logger jar from Maven.

Add trace-event-logger plug-in to RCP feature and releng-site.

Add trace-event-logger plug-in to trace-server product.

### How to test

Enable logging.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
