### PR TITLE
dpdk: fix lcore role and status inconsistency

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreAnalysisModule.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreAnalysisModule.java
@@ -40,7 +40,7 @@ public class DpdkLogicalCoreAnalysisModule extends TmfStateSystemAnalysisModule 
     private final DpdkLogicalCoreEventLayout fLayout = new DpdkLogicalCoreEventLayout();
 
     private final TmfAbstractAnalysisRequirement REQUIREMENT = new TmfAnalysisEventRequirement(ImmutableList.of(
-            fLayout.eventLcoreStateChange(), fLayout.eventServiceMapLcore()), PriorityLevel.AT_LEAST_ONE);
+            fLayout.eventLcoreStateChange(), fLayout.eventServiceRunStateSet()), PriorityLevel.AT_LEAST_ONE);
 
     @Override
     protected ITmfStateProvider createStateProvider() {

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreEventHandler.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreEventHandler.java
@@ -40,10 +40,12 @@ public class DpdkLogicalCoreEventHandler implements IDpdkEventHandler {
 
         if (eventName.equals(fLayout.eventLcoreStateChange())) {
             Integer lcoreRole = event.getContent().getFieldValue(Integer.class, fLayout.fieldLcoreState());
-            LogicalCore.setRole(ssb, Objects.requireNonNull(lcoreRole), Objects.requireNonNull(lcoreId), ts);
-        } else if (eventName.equals(fLayout.eventServiceLcoreStart())
-                || eventName.equals(fLayout.eventServiceLcoreStop())
-                || eventName.equals(fLayout.eventThreadLcoreStopped())) {
+            LogicalCore.setRole(ssb, LogicalCoreRole.fromInt(Objects.requireNonNull(lcoreRole)), Objects.requireNonNull(lcoreId), ts);
+        } else if (eventName.equals(fLayout.eventServiceLcoreStart())) {
+            LogicalCore.setRole(ssb, LogicalCoreRole.ROLE_SERVICE, Objects.requireNonNull(lcoreId), ts);
+        } else if (eventName.equals(fLayout.eventServiceLcoreStop())) {
+            LogicalCore.setRole(ssb, LogicalCoreRole.ROLE_RTE, Objects.requireNonNull(lcoreId), ts);
+        } else if (eventName.equals(fLayout.eventThreadLcoreStopped())) {
             LogicalCore.setStatus(ssb, LogicalCoreStatus.IDLE, Objects.requireNonNull(lcoreId), ts);
             LogicalCore.setFunction(ssb, 0L, Objects.requireNonNull(lcoreId), ts);
         } else if (eventName.equals(fLayout.eventThreadLcoreRunning())) {

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreEventLayout.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreEventLayout.java
@@ -28,7 +28,6 @@ public class DpdkLogicalCoreEventLayout {
     private static final String SERVICE_RUN_BEGIN = "lib.eal.service.run.begin"; //$NON-NLS-1$
     private static final String SERVICE_RUN_STATE_SET = "lib.eal.service.run.state.set"; //$NON-NLS-1$
     private static final String SERVICE_RUN_END = "lib.eal.service.run.end"; //$NON-NLS-1$
-    private static final String SERVICE_MAP_LCORE = "lib.eal.service.map.lcore"; //$NON-NLS-1$
     private static final String SERVICE_COMPONENT_REGISTER = "lib.eal.service.component.register"; //$NON-NLS-1$
 
     /* Event field names */
@@ -130,19 +129,6 @@ public class DpdkLogicalCoreEventLayout {
      */
     public String eventServiceRunEnd() {
         return SERVICE_RUN_END;
-    }
-
-    /**
-     * This event is generated when an lcore is mapped or unmapped to a service.
-     *
-     * Each core can be added or removed from running a specific service. If
-     * multiple cores are enabled on a service, a lock is used to ensure that
-     * only one core runs the service at a time.
-     *
-     * @return The event name
-     */
-    public String eventServiceMapLcore() {
-        return SERVICE_MAP_LCORE;
     }
 
     /**

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreStateProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkLogicalCoreStateProvider.java
@@ -76,7 +76,6 @@ public class DpdkLogicalCoreStateProvider extends AbstractDpdkStateProvider {
             builder.put(fLayout.eventThreadLcoreReady(), logicalCoreEventHandler);
             IDpdkEventHandler serviceEventHandler = new DpdkServiceEventHandler(fLayout);
             builder.put(fLayout.eventServiceComponentRegister(), serviceEventHandler);
-            builder.put(fLayout.eventServiceMapLcore(), serviceEventHandler);
             builder.put(fLayout.eventServiceRunBegin(), serviceEventHandler);
             builder.put(fLayout.eventServiceRunEnd(), serviceEventHandler);
             builder.put(fLayout.eventServiceRunStateSet(), serviceEventHandler);

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkServiceEventHandler.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/DpdkServiceEventHandler.java
@@ -43,17 +43,6 @@ public class DpdkServiceEventHandler implements IDpdkEventHandler {
                 LogicalCore.setServiceName(ssb, serviceName, serviceId, ts);
                 LogicalCore.setServiceStatus(ssb, ServiceStatus.REGISTERED, serviceId, ts);
             }
-        } else if (eventName.equals(fLayout.eventServiceMapLcore())) {
-            Integer lcoreId = event.getContent().getFieldValue(Integer.class, fLayout.fieldLcoreId());
-            if (lcoreId != null) {
-                LogicalCore.setServiceLcore(ssb, lcoreId, serviceId, ts);
-            }
-            Integer enabled = event.getContent().getFieldValue(Integer.class, fLayout.fieldEnabled());
-            if (enabled != null && enabled == 0) {
-                LogicalCore.setServiceStatus(ssb, ServiceStatus.DISABLED, serviceId, ts);
-            } else {
-                LogicalCore.setServiceStatus(ssb, ServiceStatus.ENABLED, serviceId, ts);
-            }
         } else if (eventName.equals(fLayout.eventServiceRunBegin())) {
             Integer lcoreId = event.getContent().getFieldValue(Integer.class, fLayout.fieldLcoreId());
             if (lcoreId != null) {

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/LogicalCore.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/LogicalCore.java
@@ -10,6 +10,7 @@
  **********************************************************************/
 package org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis;
 
+import java.util.Objects;
 import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
 
@@ -23,85 +24,174 @@ import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
 public class LogicalCore {
 
     /* Logical Core attribute names */
-    private static final String LCORES = "LCORES"; //$NON-NLS-1$
+    private static final String LCORES = "LCores"; //$NON-NLS-1$
     private static final String LCORE_FUNCTION = "LCORE_FUNCTION"; //$NON-NLS-1$
     private static final String LCORE_ROLE = "LCORE_ROLE"; //$NON-NLS-1$
     private static final String LCORE_STATUS = "LCORE_STATUS"; //$NON-NLS-1$
 
     /* Service attribute names */
-    private static final String SERVICES = "services"; //$NON-NLS-1$
+    private static final String SERVICES = "Services"; //$NON-NLS-1$
     private static final String SERVICE_CORE = "service_core"; //$NON-NLS-1$
     private static final String SERVICE_NAME = "service_name"; //$NON-NLS-1$
     private static final String SERVICE_STATUS = "service_status"; //$NON-NLS-1$
 
     /**
-     * Values for the different roles that a logical core can take
+     * Values for the different roles that a worker logical core can take
      */
-    public final class LogicalCoreRole {
+    enum LogicalCoreRole {
         /** The logical core is running in the runtime environment */
-        public static final int ROLE_RTE = 0;
+        ROLE_RTE(String.valueOf(Messages.LCoreRole_rte)),
         /** The logical core is not running in DPDK */
-        public static final int ROLE_OFF = 1;
+        ROLE_OFF(String.valueOf(Messages.LCoreRole_off)),
         /** The logical core is running the service */
-        public static final int ROLE_SERVICE = 2;
+        ROLE_SERVICE(String.valueOf(Messages.LCoreRole_service)),
         /** The logical core is not running in the EAL */
-        public static final int ROLE_NON_EAL = 3;
+        ROLE_NON_EAL(String.valueOf(Messages.LCoreRole_non_eal)),
+        /** The role of the logical core is unknown */
+        ROLE_UNKNOWN(String.valueOf(Messages.LCoreRole_unknown));
+
+        private final String fLabel;
+
+        /**
+         * Constructor
+         *
+         * @param label
+         *            String identifying the role of a LCore
+         */
+        LogicalCoreRole(String label) {
+            this.fLabel = label;
+        }
+
+        /**
+         * Get the label associated with this LCore role
+         *
+         * @return the label string
+         */
+        public String getLabel() {
+            return fLabel;
+        }
+
+        /**
+         * Convert to a LCore role from an integer
+         *
+         * @param value
+         *            integer encoding the ordinal order of the LCore role
+         * @return an {@link LogicalCoreRole}
+         */
+        public static LogicalCoreRole fromInt(int value) {
+            LogicalCoreRole[] roles = LogicalCoreRole.values();
+            if (value < 0 || value >= roles.length) {
+                return ROLE_UNKNOWN;
+            }
+            return Objects.requireNonNull(roles[value]);
+        }
     }
 
     enum LogicalCoreStatus {
-        /** Lcore is waiting for a new command */
-        IDLE,
-        /** Lcore is running */
-        RUNNING,
-        /** Not yet ready to start scheduling services */
-        DISABLED,
-        /** Command is executed */
-        OFF;
+        /** LCore is waiting for a new command */
+        IDLE(String.valueOf(Messages.LCoreStatus_idle)),
+        /** LCore is running */
+        RUNNING(String.valueOf(Messages.LCoreStatus_running)),
+        /** LCore status is unknown */
+        UNKNOWN(String.valueOf(Messages.LCoreStatus_unknown));
+
+        private final String fLabel;
+
+        /**
+         * Constructor
+         *
+         * @param label
+         *            String identifying the status of a LCore
+         */
+        LogicalCoreStatus(String label) {
+            this.fLabel = label;
+        }
+
+        /**
+         * Get the label associated with this LCore status
+         *
+         * @return the label string
+         */
+        public String getLabel() {
+            return fLabel;
+        }
+
     }
 
     enum ServiceStatus {
-        /** Unknown Status */
-        UNKNOWN,
         /** Service has been registered */
-        REGISTERED,
+        REGISTERED(String.valueOf(Messages.ServiceStatus_registered)),
         /** Service is Disabled */
-        DISABLED,
+        DISABLED(String.valueOf(Messages.ServiceStatus_disabled)),
         /** Service is Enabled */
-        ENABLED,
+        ENABLED(String.valueOf(Messages.ServiceStatus_enabled)),
         /** Service is enabled but waiting to be executed */
-        PENDING,
+        PENDING(String.valueOf(Messages.ServiceStatus_pending)),
         /** Service is running */
-        RUNNING;
+        RUNNING(String.valueOf(Messages.ServiceStatus_running)),
+        /** Service status is Unknown */
+        UNKNOWN(String.valueOf(Messages.ServiceStatus_unknown));
+
+        private final String fLabel;
+
+        /**
+         * Constructor
+         *
+         * @param label
+         *            String identifying the status of a service
+         */
+        ServiceStatus(String label) {
+            this.fLabel = label;
+        }
+
+        /**
+         * Get the label associated with this service status
+         *
+         * @return the label string
+         */
+        public String getLabel() {
+            return fLabel;
+        }
     }
 
     /**
+     * Assign a role and a status to a logical core
+     *
      * @param ssb
      *            State system builder
      * @param newRole
-     *            Role integer value to input in the state system
+     *            Role to input in the state system
      * @param lcoreId
      *            identifier number for the logical core
      * @param timestamp
      *            time to use for state change
      */
-    public static void setRole(ITmfStateSystemBuilder ssb, Integer newRole, Integer lcoreId, long timestamp) {
-        LogicalCoreStatus newStatus;
-        if (newRole == LogicalCoreRole.ROLE_RTE) {
-            newStatus = LogicalCoreStatus.IDLE;
-        } else if (newRole == LogicalCoreRole.ROLE_OFF) {
-            newStatus = LogicalCoreStatus.OFF;
-        } else {
-            Activator.getInstance().logWarning("LogicalCore setRole with unexpected role value " + newRole.toString()); //$NON-NLS-1$
-            newStatus = LogicalCoreStatus.IDLE;
+    public static void setRole(ITmfStateSystemBuilder ssb, LogicalCoreRole newRole, int lcoreId, long timestamp) {
+
+        // Change the status if the newRole is not service
+        if (newRole != LogicalCoreRole.ROLE_SERVICE) {
+            final LogicalCoreStatus newStatus;
+            if (newRole == LogicalCoreRole.ROLE_RTE) {
+                newStatus = LogicalCoreStatus.IDLE;
+            } else if (newRole == LogicalCoreRole.ROLE_OFF
+                    || newRole == LogicalCoreRole.ROLE_NON_EAL) {
+                newStatus = LogicalCoreStatus.UNKNOWN;
+            } else {
+                Activator.getInstance().logWarning("LogicalCore setRole with unexpected role value!"); //$NON-NLS-1$
+                newStatus = LogicalCoreStatus.UNKNOWN;
+            }
+            setStatus(ssb, newStatus, lcoreId, timestamp);
         }
-        setStatus(ssb, newStatus, lcoreId, timestamp);
-        // Update State system
-        int lcoreQuark = ssb.getQuarkAbsoluteAndAdd(LCORES, String.valueOf(lcoreId));
-        int lcoreRoleQuark = ssb.getQuarkRelativeAndAdd(lcoreQuark, LCORE_ROLE);
-        ssb.modifyAttribute(timestamp, newRole, lcoreRoleQuark);
+
+        // Update the state system
+        final int lcoreQuark = ssb.getQuarkAbsoluteAndAdd(LCORES, String.valueOf(lcoreId));
+        final int lcoreRoleQuark = ssb.getQuarkRelativeAndAdd(lcoreQuark, LCORE_ROLE);
+        ssb.modifyAttribute(timestamp, newRole.getLabel(), lcoreRoleQuark);
     }
 
     /**
+     * Set the status of a logical core
+     *
      * @param ssb
      *            State System builder
      * @param newStatus
@@ -114,10 +204,12 @@ public class LogicalCore {
     public static void setStatus(ITmfStateSystemBuilder ssb, LogicalCoreStatus newStatus, Integer lcoreId, long timestamp) {
         int lcoreQuark = ssb.getQuarkAbsoluteAndAdd(LCORES, String.valueOf(lcoreId));
         int lcoreRoleQuark = ssb.getQuarkRelativeAndAdd(lcoreQuark, LCORE_STATUS);
-        ssb.modifyAttribute(timestamp, newStatus, lcoreRoleQuark);
+        ssb.modifyAttribute(timestamp, newStatus.getLabel(), lcoreRoleQuark);
     }
 
     /**
+     * Record the function pointer executed by a logical core
+     *
      * @param ssb
      *            State System builder
      * @param function
@@ -179,6 +271,6 @@ public class LogicalCore {
      */
     public static void setServiceStatus(ITmfStateSystemBuilder ssb, ServiceStatus serviceStatus, Integer serviceId, long timestamp) {
         int serviceStatusQuark = ssb.getQuarkRelativeAndAdd(getServiceQuark(ssb, serviceId), SERVICE_STATUS);
-        ssb.modifyAttribute(timestamp, serviceStatus, serviceStatusQuark);
+        ssb.modifyAttribute(timestamp, serviceStatus.toString(), serviceStatusQuark);
     }
 }

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/Messages.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/Messages.java
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages
+ *
+ * @author Adel Belkhiri
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis.messages"; //$NON-NLS-1$
+    /** Logical core is idle */
+    public static @Nullable String LCoreStatus_idle = null;
+
+    /** Logical core is running */
+    public static @Nullable String LCoreStatus_running = null;
+
+    /** Logical core status is unknown */
+    public static @Nullable String LCoreStatus_unknown = null;
+
+    /** Logical core is managed by EAL */
+    public static @Nullable String LCoreRole_rte = null;
+
+    /** Logical core is not used by the application */
+    public static @Nullable String LCoreRole_off = null;
+
+    /** Logical core is used as a service */
+    public static @Nullable String LCoreRole_service = null;
+
+    /** Logical core is not managed by EAL */
+    public static @Nullable String LCoreRole_non_eal = null;
+
+    /** Logical core role is unknown */
+    public static @Nullable String LCoreRole_unknown = null;
+
+    /** Service is registered */
+    public static @Nullable String ServiceStatus_registered = null;
+
+    /** Service is enabled */
+    public static @Nullable String ServiceStatus_enabled = null;
+
+    /** Service is waiting for execution */
+    public static @Nullable String ServiceStatus_pending = null;
+
+    /** Service is disabled */
+    public static @Nullable String ServiceStatus_disabled = null;
+
+    /** Service is running */
+    public static @Nullable String ServiceStatus_running = null;
+
+    /** Service status is unknown */
+    public static @Nullable String ServiceStatus_unknown = null;
+
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+        // do nothing
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/messages.properties
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/lcore/analysis/messages.properties
@@ -1,0 +1,26 @@
+###############################################################################
+# Copyright (c) 2025 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+LCoreStatus_idle=IDLE
+LCoreStatus_running=RUNNING
+LCoreStatus_unknown=UNKNOWN
+
+LCoreRole_rte=RTE
+LCoreRole_off=OFF
+LCoreRole_service=SERVICE
+LCoreRole_non_eal=NON EAL
+LCoreRole_unknown=UNKNOWN
+
+ServiceStatus_registered=REGISTERED
+ServiceStatus_disabled=DISABLED
+ServiceStatus_enabled=ENABLED
+ServiceStatus_pending=PENDING
+ServiceStatus_running=RUNNING
+ServiceStatus_unknown=UNKNOWN


### PR DESCRIPTION
This commit fixes the following issues in the LCore analysis:

 1. The lcore role "ROLE_SERVICE" was never assigned.
 2. Certain lcore roles and statuses were not displayed because Enum values were
 not converted to strings before saving them to the state system.

These fixes ensure proper role and status assignment alongside visibility in the UI. The following screenshots are for the LCore view showing:
 - Three services running on two "RTE" LCores (with one idle LCore)
![LCore View -- Services running on RTE lcores](https://github.com/user-attachments/assets/8d25f47e-474b-4237-a26e-fa4b266f8feb)

- Five services running on three "SERVICE" LCores (with two idle LCores).
![LCore View -- Services running on Service lcores](https://github.com/user-attachments/assets/777d284b-9a09-4f96-8119-166cb5a2b876)
