### PR TITLE
server: Hide reports factory data provider

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -209,6 +209,9 @@ public class DataProviderService {
     // InAndOut analysis ID
     private static final String INANDOUT_ANALYSIS_ID = "org.eclipse.tracecompass.incubator.inandout.analysis"; //$NON-NLS-1$
 
+    // Reports factory ID
+    private static final String REPORTS_FACTORY_ID = "org.eclipse.tracecompass.incubator.analysis.core.reports.reportsDataProviderFactory"; //$NON-NLS-1$
+
     private static final @NonNull Logger LOGGER = TraceCompassLog.getLogger(DataProviderService.class);
 
     private final DataProviderManager manager = DataProviderManager.getInstance();
@@ -247,8 +250,11 @@ public class DataProviderService {
          * - Legacy InAndOut
          *   Remove default InAndOutAnalysis used in legacy Trace Compass with Eclipse UI
          *   For trace server, InAndOutAnlaysis is done using the createDataProvider endpoint below.
+         *
+         * - Reports Factory
+         *   Remove the reports factory data provider as it is not yet supported in the frond-end products.
          */
-        list.removeIf(dp -> dp.getId().endsWith(EventMatchingLatencyAnalysis.ID) || dp.getId().endsWith(INANDOUT_ANALYSIS_ID));
+        list.removeIf(dp -> dp.getId().endsWith(EventMatchingLatencyAnalysis.ID) || dp.getId().endsWith(INANDOUT_ANALYSIS_ID) || dp.getId().endsWith(REPORTS_FACTORY_ID));
 
         return Response.ok(list).build();
     }


### PR DESCRIPTION
### What it does

As reports data provider is not yet supported properly in the front-end products (e.g., Eclipse UI, vscode/theia trace extension, etc.), we hide it temporarily, and once ready, we will unhide it.

### How to test

When opening an experiment, fetch the outputs for it. In the fetched outputs list, the reports factory data provider should not be present. 

### Follow-ups

This data provider should be enabled once the front-end consumers support showing its outputs (e.g., containers/folders with different types of reports, such as images).

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
