### PR TITLE
inandout: do not share configuration table

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
@@ -28,7 +28,6 @@ import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSourceType;
 import org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigurator;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
-import org.eclipse.tracecompass.tmf.core.dataprovider.DataProviderManager;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
 import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
@@ -177,11 +176,11 @@ public class InAndOutDataProviderFactoryTest {
         assertEquals(sfTestConfig.getSourceTypeId(), config.getSourceTypeId());
         assertEquals(sfTestConfig.getParameters(), config.getParameters());
 
-        List<IDataProviderDescriptor> descriptors = DataProviderManager.getInstance().getAvailableProviders(sfTestTrace);
+        Collection<IDataProviderDescriptor> descriptors = sfFixture.getDescriptors(sfTestTrace);
         assertTrue(descriptors.contains(descriptor));
 
         configurator.removeDataProviderDescriptor(sfTestTrace, descriptor);
-        descriptors = DataProviderManager.getInstance().getAvailableProviders(sfTestTrace);
+        descriptors = sfFixture.getDescriptors(sfTestTrace);
         assertFalse(descriptors.contains(descriptor));
     }
 

--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
@@ -73,7 +73,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
     private static final String CUSTOM_IN_AND_OUT_ANALYSIS_NAME = "InAndOut Analysis ({0})";  //$NON-NLS-1$
     private static final String CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION = "Custom InAndOut analysis configured by \" {0}\""; //$NON-NLS-1$
 
-    private static final Table<String, ITmfTrace, ITmfConfiguration> fTmfConfigurationTable = HashBasedTable.create();
+    private Table<String, ITmfTrace, ITmfConfiguration> fTmfConfigurationTable = HashBasedTable.create();
 
     static {
         Bundle bundle = Platform.getBundle(Activator.PLUGIN_ID);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Make fTmfConfigurationTable simply private.
This avoids that multiple instances of the same factory class can share the table.

Unit test updated accordingly.

### How to test

Make fTmfConfigurationTable simply private, and then run the test as is on master. It will fail since a different instance of InAndOutDataProviderFactory is returned.

### Follow-ups

None

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
