### PR TITLE
inandout: Use config separator in analysis id and output id

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core.tests/src/org/eclipse/tracecompass/incubator/inandout/core/tests/analysis/InAndOutDataProviderFactoryTest.java
@@ -60,7 +60,7 @@ public class InAndOutDataProviderFactoryTest {
     private static final String CONFIG_NAME = "An InAndOut Analysis"; //$NON-NLS-1$
 
     private static final String CUSTOM_IN_AND_OUT_ANALYSIS_NAME = "InAndOut Analysis (" + CONFIG_NAME + ")"; //$NON-NLS-1$
-    private static final String CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION = "Custom InAndOut analysis configured by \" " + CONFIG_NAME + "\""; //$NON-NLS-1$
+    private static final String CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION = "Custom InAndOut analysis configured by '" + CONFIG_NAME + "'"; //$NON-NLS-1$
 
     private static final String XML_TRACE = "testfiles/stub_xml_traces/valid/analysis_dependency.xml";
     private static ITmfTrace sfTestTrace;

--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutAnalysisModule.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutAnalysisModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Ericsson
+ * Copyright (c) 2022, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0 which
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.profiling.core.instrumented.InstrumentedCallStackAnalysis;
 import org.eclipse.tracecompass.incubator.internal.inandout.core.Activator;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.TmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
@@ -106,7 +107,7 @@ public class InAndOutAnalysisModule extends InstrumentedCallStackAnalysis {
         if (config == null || fSpecifiers == null) {
             return ID;
         }
-        return ID + config.getId();
+        return ID + DataProviderConstants.CONFIG_SEPARATOR + config.getId();
     }
 
     @Override
@@ -245,7 +246,7 @@ public class InAndOutAnalysisModule extends InstrumentedCallStackAnalysis {
 
         // Remove and clear persistent data
         try {
-            IAnalysisModule module = trace.removeAnalysisModule(ID + config.getId());
+            IAnalysisModule module = trace.removeAnalysisModule(ID + DataProviderConstants.CONFIG_SEPARATOR + config.getId());
             if (module != null) {
                 module.dispose();
                 module.clearPersistentData();

--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.tracecompass.incubator.internal.inandout.core.Activator;
+import org.eclipse.tracecompass.tmf.core.component.DataProviderConstants;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSourceType;
 import org.eclipse.tracecompass.tmf.core.config.ITmfDataProviderConfigurator;
@@ -71,7 +72,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
     private static final String CONFIGURATOR_DESCRIPTION = "Configure custom InAndOut analysis"; //$NON-NLS-1$
 
     private static final String CUSTOM_IN_AND_OUT_ANALYSIS_NAME = "InAndOut Analysis ({0})";  //$NON-NLS-1$
-    private static final String CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION = "Custom InAndOut analysis configured by \" {0}\""; //$NON-NLS-1$
+    private static final String CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION = "Custom InAndOut analysis configured by \'\'{0}\'\'"; //$NON-NLS-1$
 
     private Table<String, ITmfTrace, ITmfConfiguration> fTmfConfigurationTable = HashBasedTable.create();
 
@@ -158,7 +159,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
 
         applyConfiguration(trace, config, true);
         if (fTmfConfigurationTable.contains(config.getId(), trace)) {
-            throw new TmfConfigurationException("Configuration already existis with label: " + config.getName()); //$NON-NLS-1$
+            throw new TmfConfigurationException("Configuration already exists with label: " + config.getName()); //$NON-NLS-1$
         }
         fTmfConfigurationTable.put(config.getId(), trace, config);
         return getDescriptorFromConfig(config);
@@ -261,7 +262,7 @@ public class InAndOutDataProviderFactory implements IDataProviderFactory, ITmfDa
     private static IDataProviderDescriptor getDescriptorFromConfig(ITmfConfiguration config) {
         return new DataProviderDescriptor.Builder()
                 .setParentId(ID)
-                .setId(InAndOutAnalysisModule.ID + config.getId())
+                .setId(InAndOutAnalysisModule.ID + DataProviderConstants.CONFIG_SEPARATOR + config.getId())
                 .setName(NLS.bind(CUSTOM_IN_AND_OUT_ANALYSIS_NAME, config.getName()))
                 .setDescription(NLS.bind(CUSTOM_IN_AND_OUT_ANALYSIS_DESCRIPTION, config.getName()))
                 .setProviderType(ProviderType.NONE)


### PR DESCRIPTION
### What it does

When a configuration is applied, use the CONFIG_SEPARATOR '+' before the configId in the analysisId and outputId.

### How to test

Create derived output from the factory and examine the analysisId and outputId.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
