### PR TITLE
Dpdk: Add mempool object allocation/deallocation rate analysis

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/META-INF/MANIFEST.MF
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Require-Bundle: org.eclipse.ui,
 Export-Package: org.eclipse.tracecompass.incubator.dpdk.core.trace,
  org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis,
  org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.throughput.analysis,
+ org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis,
  org.eclipse.tracecompass.incubator.internal.dpdk.core.lcore.analysis;x-friends:="org.eclipse.tracecompass.incubator.dpdk.core.tests"
 Automatic-Module-Name: org.eclipse.tracecompass.incubator.dpdk.core
 Import-Package: com.google.common.collect,

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/plugin.xml
@@ -30,6 +30,16 @@
                class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
          </tracetype>
       </module>
+      <module
+            analysis_module="org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis.DpdkMempoolAnalysisModule"
+            automatic="true"
+            id="org.eclipse.tracecompass.incubator.dpdk.mempool.analysis"
+            name="DPDK Mempool Analysis">
+         <tracetype
+               applies="true"
+               class="org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace">
+         </tracetype>
+      </module>
    </extension>
    <extension
          point="org.eclipse.tracecompass.tmf.core.analysis.ondemand">
@@ -37,7 +47,7 @@
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.distribution.analysis.DpdkPollDistributionAnalysis"
             id="org.eclipse.tracecompass.incubator.dpdk.core.ethdev.poll.distribution">
       </analysis>
-	<analysis
+      <analysis
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.poll.stats.analysis.DpdkPollStatsAnalysis"
             id="org.eclipse.tracecompass.incubator.dpdk.core.ethdev.poll.stats">
       </analysis>
@@ -59,6 +69,10 @@
       <dataProviderFactory
             class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEthdevSpinDataProviderFactory"
             id="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.dataprovider">
+      </dataProviderFactory>
+      <dataProviderFactory
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis.DpdkMempoolAllocFreeRateDataProviderFactory"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.alloc.free.dataprovider">
       </dataProviderFactory>
    </extension>
    <extension

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAllocFreeRateDataProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAllocFreeRateDataProvider.java
@@ -1,0 +1,310 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.internal.tmf.core.model.filters.FetchParametersUtils;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.StateSystemUtils;
+import org.eclipse.tracecompass.statesystem.core.exceptions.AttributeNotFoundException;
+import org.eclipse.tracecompass.statesystem.core.exceptions.StateSystemDisposedException;
+import org.eclipse.tracecompass.statesystem.core.interval.ITmfStateInterval;
+import org.eclipse.tracecompass.tmf.core.dataprovider.DataType;
+import org.eclipse.tracecompass.tmf.core.model.YModel;
+import org.eclipse.tracecompass.tmf.core.model.filters.SelectionTimeQueryFilter;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.AbstractTreeCommonXDataProvider;
+import org.eclipse.tracecompass.tmf.core.model.xy.IYModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This data provider will return a XY model showing the rate at which mempool
+ * objects were allocated and deallocated.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolAllocFreeRateDataProvider extends AbstractTreeCommonXDataProvider<DpdkMempoolAnalysisModule, TmfTreeDataModel> {
+
+    /**
+     * Extension point ID.
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.alloc.free.dataprovider"; //$NON-NLS-1$
+
+    /**
+     * Title of the {@link DpdkMempoolAllocFreeRateDataProvider}.
+     */
+    private static final String PROVIDER_TITLE = Objects.requireNonNull("DPDK Mempool Alloc/Dealloc Rate"); //$NON-NLS-1$
+    private static final TmfXYAxisDescription Y_AXIS_DESCRIPTION = new TmfXYAxisDescription(Objects.requireNonNull(Messages.DpdkMempoolAllocFreeRate_DataProvider_YAxis), "/s", DataType.NUMBER); //$NON-NLS-1$
+
+    private class MempoolBuilder {
+        private final long fId;
+        private final int fMetricQuark;
+        private final String fName;
+        private final double[] fValues;
+        private static final double SECONDS_PER_NANOSECOND = 1E-9;
+
+        private long fPrevObjectCount;
+        private long fPrevTime;
+
+        /**
+         * Constructor
+         *
+         * @param id
+         *            The series Id
+         * @param metricQuark
+         *            quark
+         * @param name
+         *            The name of this series
+         * @param length
+         *            The length of the series
+         */
+        public MempoolBuilder(long id, int metricQuark, String name, int length) {
+            fId = id;
+            fMetricQuark = metricQuark;
+            fName = name;
+            fValues = new double[length];
+        }
+
+        /**
+         * Update the rate value at the specified index
+         *
+         * @param pos
+         *            The index to update
+         * @param objCount
+         *            Number of mempool objects allocated or freed by a worker
+         *            thread
+         * @param currTime
+         *            Timestamp related to the observation
+         */
+        public void updateValue(int pos, long objCount, long currTime) {
+            long deltaCount = objCount - fPrevObjectCount;
+            long deltaTime = currTime - fPrevTime;
+
+            double rate = 0;
+
+            if (deltaCount > 0 && deltaTime > 0) {
+                rate = deltaCount / (deltaTime * SECONDS_PER_NANOSECOND);
+            }
+
+            fValues[pos] = rate;
+            fPrevObjectCount = objCount;
+            fPrevTime = currTime;
+        }
+
+        public void setPrevObservation(long prevObjCount, long timestamp) {
+            fPrevObjectCount = prevObjCount;
+            fPrevTime = timestamp;
+        }
+
+        /**
+         * Build a data series
+         *
+         * @param yAxisDescription
+         *            Description for the Y axis
+         * @return an IYModel
+         */
+        public IYModel build(TmfXYAxisDescription yAxisDescription) {
+            return new YModel(fId, fName, fValues, yAxisDescription);
+        }
+
+    }
+
+    /**
+     * Constructor
+     */
+    public DpdkMempoolAllocFreeRateDataProvider(ITmfTrace trace, DpdkMempoolAnalysisModule module) {
+        super(trace, module);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    private static String getMempoolName(ITmfStateSystem ss, Integer mempoolNameQuark) {
+        ITmfStateInterval interval = StateSystemUtils.queryUntilNonNullValue(ss, mempoolNameQuark, ss.getStartTime(), ss.getCurrentEndTime());
+        if (interval != null) {
+            return String.valueOf(interval.getValue());
+        }
+        return "no_name"; //$NON-NLS-1$
+    }
+
+    @Override
+    protected TmfTreeModel<TmfTreeDataModel> getTree(ITmfStateSystem ss, Map<String, Object> parameters, @Nullable IProgressMonitor monitor) {
+        List<TmfTreeDataModel> nodes = new ArrayList<>();
+        long rootId = getId(ITmfStateSystem.ROOT_ATTRIBUTE);
+        nodes.add(new TmfTreeDataModel(rootId, -1, Collections.singletonList(Objects.requireNonNull(getTrace().getName())), false, null));
+
+        try {
+            for (int mempoolQuark : ss.getQuarks(DpdkMempoolAttributes.MEMPOOLS, "*")) { //$NON-NLS-1$
+                long mempoolId = getId(mempoolQuark);
+
+                int nameQuark = ss.getQuarkRelative(mempoolQuark, DpdkMempoolAttributes.MEMPOOL_NAME);
+                String mempoolName = getMempoolName(ss, nameQuark);
+                nodes.add(new TmfTreeDataModel(mempoolId, rootId, Collections.singletonList(mempoolName), false, null));
+
+                int threadsQuark = ss.optQuarkRelative(mempoolQuark, DpdkMempoolAttributes.THREADS);
+                if (threadsQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                    for (Integer threadQuark : ss.getQuarks(threadsQuark, "*")) { //$NON-NLS-1$
+                        long threadId = getId(threadQuark);
+                        String threadName = ss.getAttributeName(threadQuark);
+                        nodes.add(new TmfTreeDataModel(threadId, mempoolId, Collections.singletonList(threadName), false, null));
+
+                        int allocQuark = ss.optQuarkRelative(threadQuark, DpdkMempoolAttributes.THREAD_OBJ_ALLOC);
+                        if (allocQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                            long allocMetricId = getId(allocQuark);
+                            nodes.add(new TmfTreeDataModel(allocMetricId, threadId, Collections.singletonList(DpdkMempoolAttributes.THREAD_OBJ_ALLOC), true, null));
+                        }
+
+                        int deallocMetricQuark = ss.optQuarkRelative(threadQuark, DpdkMempoolAttributes.THREAD_OBJ_FREE);
+                        if (deallocMetricQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                            long deallocMetricId = getId(deallocMetricQuark);
+                            nodes.add(new TmfTreeDataModel(deallocMetricId, threadId, Collections.singletonList(DpdkMempoolAttributes.THREAD_OBJ_FREE), true, null));
+                        }
+                    }
+                }
+            }
+        } catch (AttributeNotFoundException | IndexOutOfBoundsException e) {
+            Activator.getInstance().logError(e.getMessage());
+        }
+        return new TmfTreeModel<>(Collections.emptyList(), nodes);
+    }
+
+    @Override
+    protected @Nullable Collection<IYModel> getYSeriesModels(ITmfStateSystem ss,
+            Map<String, Object> fetchParameters,
+            @Nullable IProgressMonitor monitor) throws StateSystemDisposedException {
+
+        SelectionTimeQueryFilter filter = FetchParametersUtils.createSelectionTimeQuery(fetchParameters);
+        if (filter == null) {
+            return null;
+        }
+
+        long[] xValues = filter.getTimesRequested();
+        if (xValues.length <= 1) {
+            return Collections.emptyList();
+        }
+
+        Map<Integer, MempoolBuilder> builderByQuark = initBuilders(ss, filter);
+        if (builderByQuark.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        long halfStepSize = (xValues[1] - xValues[0]) / 2;
+        long startTime = Math.max(filter.getStart() - halfStepSize, ss.getStartTime());
+
+        // Seed each builder with the first observation
+        for (MempoolBuilder builder : builderByQuark.values()) {
+            ITmfStateInterval iv = ss.querySingleState(startTime, builder.fMetricQuark);
+            Object v = iv.getValue();
+            long count = (v instanceof Number) ? ((Number) v).longValue() : 0L;
+            builder.setPrevObservation(count, startTime);
+        }
+
+        // Shift all xValues to the left to center them on interval midpoints
+        int n = xValues.length;
+        List<Long> adjustedQueryTimes = new ArrayList<>(n);
+        for (int i = 1; i < n; i++) {
+            adjustedQueryTimes.add(xValues[i] - halfStepSize);
+        }
+        adjustedQueryTimes.add(Math.min(xValues[n - 1] + halfStepSize, ss.getCurrentEndTime()));
+
+        List<ITmfStateInterval> intervals = StreamSupport.stream(ss.query2D(builderByQuark.keySet(), adjustedQueryTimes)
+                .spliterator(), false)
+                .sorted(Comparator.comparingLong(ITmfStateInterval::getStartTime))
+                .collect(Collectors.toList());
+
+        for (ITmfStateInterval interval : intervals) {
+            if (monitor != null && monitor.isCanceled()) {
+                return null;
+            }
+
+            int from = Collections.binarySearch(adjustedQueryTimes, interval.getStartTime());
+            from = (from >= 0) ? from : -1 - from;
+
+            int to = Collections.binarySearch(adjustedQueryTimes, interval.getEndTime());
+            to = (to >= 0) ? to + 1 : -1 - to;
+
+            if (from < to) {
+                Object value = interval.getValue();
+                long nbObjCount = value instanceof Number ? ((Number) value).longValue() : 0L;
+                MempoolBuilder builder = builderByQuark.get(interval.getAttribute());
+                if (builder != null) {
+                    for (int j = from; j < to; j++) {
+                        builder.updateValue(j, nbObjCount, adjustedQueryTimes.get(j));
+                    }
+                }
+            }
+        }
+
+        return ImmutableList.copyOf(
+                builderByQuark.values().stream()
+                        .map(builder -> builder.build(Y_AXIS_DESCRIPTION))
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    protected boolean isCacheable() {
+        return true;
+    }
+
+    @Override
+    protected String getTitle() {
+        return PROVIDER_TITLE;
+    }
+
+    private Map<Integer, MempoolBuilder> initBuilders(ITmfStateSystem ss, SelectionTimeQueryFilter filter) {
+        int length = filter.getTimesRequested().length;
+        Map<Integer, MempoolBuilder> builderMap = new HashMap<>();
+
+        for (Entry<Long, Integer> entry : getSelectedEntries(filter).entrySet()) {
+            int quark = Objects.requireNonNull(entry.getValue());
+            try {
+                String metricLabel = ss.getAttributeName(quark);
+                if (DpdkMempoolAttributes.THREAD_OBJ_ALLOC.equals(metricLabel)
+                        || (DpdkMempoolAttributes.THREAD_OBJ_FREE.equals(metricLabel))) {
+
+                    int threadQuark = ss.getParentAttributeQuark(quark);
+                    String threadName = ss.getAttributeName(threadQuark);
+
+                    int threadsQuark = ss.getParentAttributeQuark(threadQuark);
+                    int mempoolQuark = ss.getParentAttributeQuark(threadsQuark);
+                    String mempoolName = ss.getAttributeName(mempoolQuark);
+
+                    String name = getTrace().getName() + '/' + mempoolName + '/' + threadName + '/' + metricLabel;
+                    builderMap.put(quark, new MempoolBuilder(entry.getKey(), quark, name, length));
+                }
+            } catch (IndexOutOfBoundsException e) {
+                Activator.getInstance().logError(e.getMessage());
+            }
+        }
+        return builderMap;
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAllocFreeRateDataProviderFactory.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAllocFreeRateDataProviderFactory.java
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderDescriptor.ProviderType;
+import org.eclipse.tracecompass.tmf.core.dataprovider.IDataProviderFactory;
+import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.tree.ITmfTreeDataModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.ITmfTreeXYDataProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
+
+/**
+ * Factory to create instances of the {@link DpdkMempoolAllocFreeRateDataProvider}.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolAllocFreeRateDataProviderFactory implements IDataProviderFactory {
+    private static final IDataProviderDescriptor DESCRIPTOR = new DataProviderDescriptor.Builder()
+            .setId(DpdkMempoolAllocFreeRateDataProvider.ID)
+            .setName("Dpdk Mempool Alloc/Free Rate") //$NON-NLS-1$
+            .setDescription("XY chart showing the rate at which mempool objects were allocated and freed") //$NON-NLS-1$
+            .setProviderType(ProviderType.TREE_TIME_XY)
+            .build();
+
+    @Override
+    public @Nullable ITmfTreeXYDataProvider<? extends ITmfTreeDataModel> createProvider(ITmfTrace trace) {
+        DpdkMempoolAnalysisModule module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkMempoolAnalysisModule.class, DpdkMempoolAnalysisModule.ID);
+        if (module == null) {
+            return null;
+        }
+        module.schedule();
+        return new DpdkMempoolAllocFreeRateDataProvider(trace, module);
+    }
+
+    @Override
+    public Collection<IDataProviderDescriptor> getDescriptors(ITmfTrace trace) {
+        DpdkMempoolAnalysisModule module = TmfTraceUtils.getAnalysisModuleOfClass(trace, DpdkMempoolAnalysisModule.class, DpdkMempoolAnalysisModule.ID);
+        return module != null ? Collections.singletonList(DESCRIPTOR) : Collections.emptyList();
+    }
+
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAnalysisModule.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAnalysisModule.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import java.util.Collections;
+
+import org.eclipse.tracecompass.incubator.dpdk.core.trace.DpdkTrace;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAbstractAnalysisRequirement.PriorityLevel;
+import org.eclipse.tracecompass.tmf.core.analysis.requirements.TmfAnalysisEventRequirement;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.statesystem.TmfStateSystemAnalysisModule;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A DPDK mempool is a collection of pre-allocated, fixed-size memory objects.
+ * By analyzing a subset of events from `lib.mempool.*`, this module analyzes
+ * the way DPDK worker threads allocate and deallocate these objects.
+ *
+ * Key metrics that can be obtained through this analysis include:
+ * <ul>
+ * <li><strong>Object Allocation/Deallocation Rates</strong>: Measures the rate
+ * at which mempool objects were allocated and freed.</li>
+ * <li><strong>Mempool Usage</strong>: Monitors mempool utilization over
+ * time.</li>
+ * </ul>
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolAnalysisModule extends TmfStateSystemAnalysisModule {
+
+    /** The ID of this analysis module */
+    public static final String ID = "org.eclipse.tracecompass.incubator.dpdk.mempool.analysis"; //$NON-NLS-1$
+
+    private final TmfAbstractAnalysisRequirement REQUIREMENT = new TmfAnalysisEventRequirement(ImmutableList.of(
+            DpdkMempoolEventLayout.eventMempoolCreate(), DpdkMempoolEventLayout.eventMempoolCreateEmpty()), PriorityLevel.AT_LEAST_ONE);
+
+    @Override
+    protected ITmfStateProvider createStateProvider() {
+        ITmfTrace trace = getTrace();
+        if (trace instanceof DpdkTrace) {
+            return new DpdkMempoolStateProvider(trace, ID);
+        }
+        throw new IllegalStateException("Trace " + trace + "(" + (trace == null ? "null" : trace.getClass().getCanonicalName()) + ")" + " is not of the type DpdkTrace."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    @Override
+    public Iterable<TmfAbstractAnalysisRequirement> getAnalysisRequirements() {
+        return Collections.singleton(REQUIREMENT);
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAttributes.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolAttributes.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+/**
+ * This class defines all the attribute names used in the state system.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolAttributes {
+    /** Root attribute for DPDK Mempools */
+    public static final String MEMPOOLS = "Mempools"; //$NON-NLS-1$
+    /** Name of the mempool */
+    public static final String MEMPOOL_NAME = "name"; //$NON-NLS-1$
+    /** List of threads using the mempool */
+    public static final String THREADS = "threads"; //$NON-NLS-1$
+    /** Number of of objects allocated by a worker thread */
+    public static final String THREAD_OBJ_ALLOC = "alloc"; //$NON-NLS-1$
+    /** Number of of objects deallocated by a worker thread */
+    public static final String THREAD_OBJ_FREE = "free"; //$NON-NLS-1$
+
+    private DpdkMempoolAttributes() {
+        // do nothing
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolEventHandler.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolEventHandler.java
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import java.util.Objects;
+
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.Activator;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
+import org.eclipse.tracecompass.statesystem.core.ITmfStateSystemBuilder;
+import org.eclipse.tracecompass.statesystem.core.StateSystemBuilderUtils;
+import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
+
+/**
+ * Event handler to process the DPDK events required for the
+ * {@link DpdkMempoolAnalysisModule} analysis
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolEventHandler implements IDpdkEventHandler {
+
+    DpdkMempoolEventHandler() {
+        // do nothing
+    }
+
+    private static void updateThreadCount(ITmfStateSystemBuilder ssb, Long mempoolId, String threadName, String metricLabel, int nbObjs, long ts) {
+        int mempoolQuark = ssb.optQuarkAbsolute(DpdkMempoolAttributes.MEMPOOLS, mempoolId.toString());
+
+        if (mempoolQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+            int threadsQuark = ITmfStateSystem.INVALID_ATTRIBUTE;
+            try {
+                threadsQuark = ssb.getQuarkRelativeAndAdd(mempoolQuark, DpdkMempoolAttributes.THREADS);
+            } catch (IndexOutOfBoundsException e) {
+                Activator.getInstance().logError(e.getMessage());
+            }
+
+            if (threadsQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                int threadQuark = ssb.getQuarkRelativeAndAdd(threadsQuark, threadName);
+                int metricQuark = ssb.getQuarkRelativeAndAdd(threadQuark, metricLabel);
+                StateSystemBuilderUtils.incrementAttributeLong(ssb, ts, metricQuark, nbObjs);
+            }
+        }
+    }
+
+    @Override
+    public void handleEvent(ITmfStateSystemBuilder ssb, ITmfEvent event) {
+        String eventName = event.getName();
+        long ts = event.getTimestamp().getValue();
+        Long mempoolId = event.getContent().getFieldValue(Long.class, DpdkMempoolEventLayout.fieldMempoolId());
+        Objects.requireNonNull(mempoolId);
+
+        if (eventName.equals(DpdkMempoolEventLayout.eventMempoolCreate()) ||
+                eventName.equals(DpdkMempoolEventLayout.eventMempoolCreateEmpty())) {
+            String mempoolName = event.getContent().getFieldValue(String.class, DpdkMempoolEventLayout.fieldMempoolName());
+            if (mempoolName != null) {
+                int mempoolQuark = ssb.getQuarkAbsoluteAndAdd(DpdkMempoolAttributes.MEMPOOLS, String.valueOf(mempoolId));
+                int nameQuark = ssb.getQuarkRelativeAndAdd(mempoolQuark, DpdkMempoolAttributes.MEMPOOL_NAME);
+                ssb.modifyAttribute(ts, mempoolName, nameQuark);
+            }
+        } else if (eventName.equals(DpdkMempoolEventLayout.eventMempoolFree())) {
+            int mempoolQuark = ssb.optQuarkAbsolute(DpdkMempoolAttributes.MEMPOOLS, mempoolId.toString());
+            if (mempoolQuark != ITmfStateSystem.INVALID_ATTRIBUTE) {
+                for (int quark : ssb.getSubAttributes(mempoolQuark, true)) {
+                    ssb.modifyAttribute(ts, null, quark);
+                }
+            }
+        } else if (eventName.equals(DpdkMempoolEventLayout.eventMempoolGenericPut())) {
+            String threadName = event.getContent().getFieldValue(String.class, DpdkMempoolEventLayout.fieldThreadName());
+            Integer nbObjs = event.getContent().getFieldValue(Integer.class, DpdkMempoolEventLayout.fieldMempoolNbObjs());
+
+            if (threadName != null && nbObjs != null) {
+                updateThreadCount(ssb, mempoolId, threadName, DpdkMempoolAttributes.THREAD_OBJ_FREE, nbObjs, ts);
+            }
+        } else if (eventName.equals(DpdkMempoolEventLayout.eventMempoolGenericGet())) {
+            String threadName = event.getContent().getFieldValue(String.class, DpdkMempoolEventLayout.fieldThreadName());
+            Integer nbObjs = event.getContent().getFieldValue(Integer.class, DpdkMempoolEventLayout.fieldMempoolNbObjs());
+
+            if (threadName != null && nbObjs != null) {
+                updateThreadCount(ssb, mempoolId, threadName, DpdkMempoolAttributes.THREAD_OBJ_ALLOC, nbObjs, ts);
+            }
+        } else {
+            Activator.getInstance().logError(eventName + " is an unexpected event!"); //$NON-NLS-1$
+        }
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolEventLayout.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolEventLayout.java
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+/**
+ * This class defines the names of DPDK mempool-related events and their fields.
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolEventLayout {
+    /* Event names */
+    private static final String MEMPOOL_CREATE = "lib.mempool.create"; //$NON-NLS-1$
+    private static final String MEMPOOL_CREATE_EMPTY = "lib.mempool.create.empty"; //$NON-NLS-1$
+    private static final String MEMPOOL_GENERIC_GET = "lib.mempool.generic.get"; //$NON-NLS-1$
+    private static final String MEMPOOL_GENERIC_PUT = "lib.mempool.generic.put"; //$NON-NLS-1$
+    private static final String MEMPOOL_FREE = "lib.mempool.free"; //$NON-NLS-1$
+
+    /* Event field names */
+    private static final String MEMPOOL_ID = "mempool"; //$NON-NLS-1$
+    private static final String MEMPOOL_NAME = "name"; //$NON-NLS-1$
+    private static final String MEMPOOL_NB_OBJS = "nb_objs"; //$NON-NLS-1$
+    private static final String THREAD_NAME = "context.name"; //$NON-NLS-1$
+    private static final String CPU_ID = "context.cpu_id"; //$NON-NLS-1$
+
+    private DpdkMempoolEventLayout() {
+        // do nothing
+    }
+
+    // ------------------------------------------------------------------------
+    // Event names
+    // ------------------------------------------------------------------------
+
+    /**
+     * This event is generated when a new mempool is created
+     *
+     * @return The event name
+     */
+    public static String eventMempoolCreate() {
+        return MEMPOOL_CREATE;
+    }
+
+    /**
+     * This event is generated when a new empty mempool is created
+     *
+     * @return The event name
+     */
+    public static String eventMempoolCreateEmpty() {
+        return MEMPOOL_CREATE_EMPTY;
+    }
+
+    /**
+     * This event is generated after getting an object from a mempool
+     *
+     * @return The event name
+     */
+    public static String eventMempoolGenericGet() {
+        return MEMPOOL_GENERIC_GET;
+    }
+
+    /**
+     * This event is generated after putting an object back to the mempool
+     *
+     * @return The event name
+     */
+    public static String eventMempoolGenericPut() {
+        return MEMPOOL_GENERIC_PUT;
+    }
+
+    /**
+     * This event is triggered when a mempool is freed
+     *
+     * @return The event name
+     */
+    public static String eventMempoolFree() {
+        return MEMPOOL_FREE;
+    }
+
+    // ------------------------------------------------------------------------
+    // Event field names
+    // ------------------------------------------------------------------------
+
+    /**
+     * @return The name of the field specifying the ID of the mempool
+     */
+    public static String fieldMempoolId() {
+        return MEMPOOL_ID;
+    }
+
+    /**
+     * @return The name of the field specifying the name of the mempool
+     */
+    public static String fieldMempoolName() {
+        return MEMPOOL_NAME;
+    }
+
+    /**
+     * @return The name of the field specifying the number of objects retrieved
+     *         or returned back to the mempool
+     */
+    public static String fieldMempoolNbObjs() {
+        return MEMPOOL_NB_OBJS;
+    }
+
+    /**
+     * @return The name of the field indicating the name of the thread
+     *         performing the get/put operation
+     */
+    public static String fieldThreadName() {
+        return THREAD_NAME;
+    }
+
+    /**
+     * @return The name of the field indicating the ID of the CPU on which the
+     *         DPDK event was recorded
+     */
+    public static String fieldCpuId() {
+        return CPU_ID;
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolStateProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/DpdkMempoolStateProvider.java
@@ -1,0 +1,107 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.AbstractDpdkStateProvider;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.analysis.IDpdkEventHandler;
+import org.eclipse.tracecompass.tmf.core.statesystem.ITmfStateProvider;
+import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ *
+ * <p>
+ * Dpdk Mempool State Provider
+ * </p>
+ * <p>
+ * In the state system, there is a single root attribute with the following
+ * structure:
+ * </p>
+ *
+ * <p>
+ * Mempools: Contains information for each mempool. Each mempool has an
+ * <em>ID</em>, a name, and a <em>Threads</em> sub-attribute. Under
+ * <em>Threads</em>, each thread’s name is listed, along with two
+ * sub-attributes, the <em>alloc</em> and <em>free</em>, which track the total
+ * number of mempool objects that have been allocated or freed so far through
+ * get/put operations.
+ * </p>
+ *
+ * <pre>
+ * Mempools
+ *  | - <ID>
+ *       | - name  -> Mempool name
+ *       | - Threads  -> List of DPDK threads using the mempool
+ *             | - <Thread Name> -> Name of the DPDK thread
+ *                  | - alloc -> Current number of mempool objects being allocated
+ *                  | - free -> Current number of mempool objects being freed
+ * </pre>
+ *
+ *
+ * @author Adel Belkhiri
+ */
+public class DpdkMempoolStateProvider extends AbstractDpdkStateProvider {
+
+    private static final int VERSION = 1;
+    /** Map events needed for this analysis with their handler functions */
+    private @Nullable Map<String, IDpdkEventHandler> fEventNames;
+
+    /**
+     * Constructor
+     *
+     * @param trace
+     *            trace
+     * @param id
+     *            id
+     */
+    protected DpdkMempoolStateProvider(ITmfTrace trace, String id) {
+        super(trace, id);
+    }
+
+    /**
+     * Get the version of this state provider
+     */
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    /**
+     * Get a new instance
+     */
+    @Override
+    public ITmfStateProvider getNewInstance() {
+        return new DpdkMempoolStateProvider(this.getTrace(), DpdkMempoolAnalysisModule.ID);
+    }
+
+    @Override
+    protected @Nullable IDpdkEventHandler getEventHandler(String eventName) {
+        if (fEventNames == null) {
+            ImmutableMap.Builder<String, IDpdkEventHandler> builder = ImmutableMap.builder();
+            IDpdkEventHandler mempoolEventHandler = new DpdkMempoolEventHandler();
+            builder.put(DpdkMempoolEventLayout.eventMempoolCreate(), mempoolEventHandler);
+            builder.put(DpdkMempoolEventLayout.eventMempoolCreateEmpty(), mempoolEventHandler);
+            builder.put(DpdkMempoolEventLayout.eventMempoolGenericGet(), mempoolEventHandler);
+            builder.put(DpdkMempoolEventLayout.eventMempoolGenericPut(), mempoolEventHandler);
+            builder.put(DpdkMempoolEventLayout.eventMempoolFree(), mempoolEventHandler);
+
+            fEventNames = builder.build();
+        }
+        if (fEventNames != null) {
+            return fEventNames.get(eventName);
+        }
+        return null;
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/Messages.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/Messages.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for {@link DpdkMempoolAnalysisModule} based data providers
+ *
+ * @author Adel Belkhiri
+ */
+@SuppressWarnings("javadoc")
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis.messages"; //$NON-NLS-1$
+
+    public static @Nullable String DpdkMempoolAllocFreeRate_DataProvider_YAxis;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+        // do nothing
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/messages.properties
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/messages.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2025 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+DpdkMempoolAllocFreeRate_DataProvider_YAxis=Rate

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/package-info.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.core/src/org/eclipse/tracecompass/incubator/internal/dpdk/core/mempool/analysis/package-info.java
@@ -1,0 +1,12 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+@org.eclipse.jdt.annotation.NonNullByDefault
+package org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis;

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/plugin.xml
@@ -32,6 +32,13 @@
                class="org.eclipse.tracecompass.incubator.internal.dpdk.core.ethdev.spin.analysis.DpdkEthdevSpinAnalysisModule">
          </analysisModuleClass>
       </output>
+      <output
+            class="org.eclipse.tracecompass.tmf.ui.analysis.TmfAnalysisViewOutput"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate.view">
+         <analysisId
+               id="org.eclipse.tracecompass.incubator.dpdk.mempool.analysis">
+         </analysisId>
+      </output>
    </extension>
    <extension
          point="org.eclipse.ui.views">
@@ -66,6 +73,13 @@
             class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.ThreadSpinStatisticsView"
             id="org.eclipse.tracecompass.incubator.internal.dpdk.ui.ethdev.spin.statistics.view"
             name="Ethernet PMD Effective Busyness"
+            restorable="true">
+      </view>
+      <view
+            category="org.eclipse.tracecompass.incubator.internal.dpdk.ui.views.category"
+            class="org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate.MempoolAllocFreeRateView"
+            id="org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate.view"
+            name="Mempool Objects Alloc/Free Rate"
             restorable="true">
       </view>
    </extension>

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/MempoolAllocFreeRateView.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/MempoolAllocFreeRateView.java
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.incubator.internal.dpdk.core.mempool.analysis.DpdkMempoolAllocFreeRateDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.TmfViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.AbstractSelectTreeViewer2;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.ITmfTreeColumnDataProvider;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfGenericTreeEntry;
+import org.eclipse.tracecompass.tmf.ui.viewers.tree.TmfTreeColumnData;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.TmfXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+import org.eclipse.tracecompass.tmf.ui.views.xychart.TmfChartView;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This views shows the rate at which mempool objects were allocated/deallocated
+ *
+ * @author Adel Belkhiri
+ */
+public class MempoolAllocFreeRateView extends TmfChartView {
+
+    /**
+     * Identifier of this view
+     */
+    public static final String ID = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate.view"; //$NON-NLS-1$
+    private static final double RESOLUTION = 0.2;
+
+    /**
+     * Constructor
+     */
+    public MempoolAllocFreeRateView() {
+        super(Messages.MempoolAllocFreeRateView_Title);
+    }
+
+    @Override
+    protected TmfXYChartViewer createChartViewer(Composite parent) {
+        TmfXYChartSettings settings = new TmfXYChartSettings(Messages.MempoolAllocFreeRateView_Title, Messages.MempoolAllocFreeRateViewer_XAxis, Messages.MempoolAllocFreeRateViewer_YAxis, RESOLUTION);
+        return new MempoolAllocFreeRateViewer(parent, settings, DpdkMempoolAllocFreeRateDataProvider.ID);
+    }
+
+    @Override
+    protected TmfViewer createLeftChildViewer(@Nullable Composite parent) {
+        return new AbstractSelectTreeViewer2(parent, 1, DpdkMempoolAllocFreeRateDataProvider.ID) {
+            @Override
+            protected ITmfTreeColumnDataProvider getColumnDataProvider() {
+                return () -> ImmutableList.of(createColumn(Messages.MempoolAllocFreeRateTreeViewer_MempoolName, Comparator.comparing(TmfGenericTreeEntry::getName)),
+                        new TmfTreeColumnData(Messages.MempoolAllocFreeRateTreeViewer_Legend));
+            }
+        };
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/MempoolAllocFreeRateViewer.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/MempoolAllocFreeRateViewer.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfFilteredXYChartViewer;
+import org.eclipse.tracecompass.tmf.ui.viewers.xychart.linechart.TmfXYChartSettings;
+
+/**
+ * Viewer for the {@link MempoolAllocFreeRateView} view
+ *
+ * @author Adel Belkhiri
+ */
+public class MempoolAllocFreeRateViewer extends TmfFilteredXYChartViewer {
+
+    private static final int DEFAULT_SERIES_WIDTH = 2;
+
+    /**
+     * Constructor
+     *
+     * @param parent
+     *            Parent composite
+     * @param settings
+     *            Chart settings
+     * @param providerId
+     *            Data provider ID
+     */
+    public MempoolAllocFreeRateViewer(Composite parent, TmfXYChartSettings settings, String providerId) {
+        super(parent, settings, providerId);
+    }
+
+    @Override
+    public @NonNull OutputElementStyle getSeriesStyle(@NonNull Long seriesId) {
+        return getPresentationProvider().getSeriesStyle(seriesId, StyleProperties.SeriesType.LINE, DEFAULT_SERIES_WIDTH);
+    }
+
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/Messages.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/Messages.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Messages for the {@link MempoolAllocFreeRateViewer} view
+ *
+ * @author Adel Belkhiri
+ */
+public class Messages extends NLS {
+    private static final String BUNDLE_NAME = "org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate.messages"; //$NON-NLS-1$
+    /** Title of the view */
+    public static @Nullable String MempoolAllocFreeRateView_Title;
+    /** X axis caption */
+    public static @Nullable String MempoolAllocFreeRateViewer_XAxis;
+    /** Y axis caption */
+    public static @Nullable String MempoolAllocFreeRateViewer_YAxis;
+    /** Mempool Name column */
+    public static @Nullable String MempoolAllocFreeRateTreeViewer_MempoolName;
+    /** Legend Column */
+    public static @Nullable String MempoolAllocFreeRateTreeViewer_Legend;
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+
+    private Messages() {
+        // do nothing
+    }
+}

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/messages.properties
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/messages.properties
@@ -1,0 +1,15 @@
+###############################################################################
+# Copyright (c) 2025 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+MempoolAllocFreeRateView_Title=Mempool Alloc/Free Rate View
+MempoolAllocFreeRateViewer_XAxis=Time
+MempoolAllocFreeRateViewer_YAxis=Rate (#/s)
+MempoolAllocFreeRateTreeViewer_MempoolName=Mempools
+MempoolAllocFreeRateTreeViewer_Legend=Legend

--- a/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/package-info.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.dpdk.ui/src/org/eclipse/tracecompass/incubator/internal/dpdk/ui/mempool/alloc/free/rate/package-info.java
@@ -1,0 +1,11 @@
+/**********************************************************************
+ * Copyright (c) 2025 École Polytechnique de Montréal
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.internal.dpdk.ui.mempool.alloc.free.rate;


### PR DESCRIPTION
This PR introduces a new analysis tool for DPDK traces focused on the Mempool library. By tracking how frequently DPDK threads allocate and free mempool objects, this analysis provides insights into application memory usage patterns. Since the Mempool library is used by the Mbuf library—which is leveraged by almost any DPDK application—this analysis can help identify memory-related bottlenecks and optimize mempools usage.
