### PR TITLE
releng: Add legacy-e4.34/traceserver.product and remove obsolete legacy

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy-e4.34/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy-e4.34/traceserver.product
@@ -11,11 +11,11 @@
 -noSplash
 -data @noDefault
       </programArgs>
-      <programArgsLin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=11
+      <programArgsLin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=17
       </programArgsLin>
-      <programArgsMac>-Xms512m -Xmx1024m -XstartOnFirstThread -Dosgi.requiredJavaVersion=11 -Dorg.eclipse.swt.internal.carbon.smallFonts
+      <programArgsMac>-Xms512m -Xmx1024m -XstartOnFirstThread -Dosgi.requiredJavaVersion=17 -Dorg.eclipse.swt.internal.carbon.smallFonts
       </programArgsMac>
-      <programArgsWin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=11
+      <programArgsWin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=17
       </programArgsWin>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -30,9 +30,9 @@
    </launcher>
 
    <vm>
-      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
-      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</macos>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</windows>
    </vm>
 
    <license>
@@ -94,6 +94,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </license>
 
    <plugins>
+      <plugin id="ch.qos.logback.classic"/>
+      <plugin id="ch.qos.logback.core"/>
       <plugin id="com.fasterxml.jackson.core.jackson-annotations"/>
       <plugin id="com.fasterxml.jackson.core.jackson-core"/>
       <plugin id="com.fasterxml.jackson.core.jackson-databind"/>
@@ -105,7 +107,10 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations"/>
       <plugin id="com.google.gson"/>
       <plugin id="com.google.guava"/>
+      <plugin id="com.google.guava.failureaccess"/>
       <plugin id="com.ibm.icu"/>
+      <plugin id="com.sun.jna"/>
+      <plugin id="com.sun.jna.platform"/>
       <plugin id="com.sun.xml.bind.jaxb-osgi"/>
       <plugin id="io.github.classgraph.classgraph"/>
       <plugin id="io.swagger.core.v3.swagger-annotations"/>
@@ -113,22 +118,21 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="io.swagger.core.v3.swagger-integration"/>
       <plugin id="io.swagger.core.v3.swagger-jaxrs2"/>
       <plugin id="io.swagger.core.v3.swagger-models"/>
+      <plugin id="jakarta.activation-api" version="1.2.2"/>
+      <plugin id="jakarta.annotation-api"/>
       <plugin id="jakarta.servlet-api"/>
       <plugin id="jakarta.validation.jakarta.validation-api"/>
-      <plugin id="jakarta.xml.bind"/>
+      <plugin id="jakarta.ws.rs-api"/>
+      <plugin id="jakarta.xml.bind-api" version="2.3.3"/>
       <plugin id="javassist"/>
-      <plugin id="javax.activation"/>
-      <plugin id="javax.annotation"/>
-      <plugin id="javax.el"/>
+      <plugin id="javax.annotation-api"/>
       <plugin id="javax.inject"/>
       <plugin id="javax.servlet-api"/>
-      <plugin id="javax.ws.rs"/>
-      <plugin id="javax.xml"/>
-      <plugin id="javax.xml.bind"/>
-      <plugin id="javax.xml.stream"/>
+      <plugin id="json"/>
       <plugin id="org.antlr.runtime"/>
       <plugin id="org.aopalliance"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.lang3"/>
       <plugin id="org.apache.felix.gogo.command"/>
       <plugin id="org.apache.felix.gogo.runtime"/>
@@ -150,19 +154,26 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.emf.common"/>
       <plugin id="org.eclipse.equinox.app"/>
       <plugin id="org.eclipse.equinox.common"/>
+      <plugin id="org.eclipse.equinox.http.service.api"/>
       <plugin id="org.eclipse.equinox.launcher"/>
       <plugin id="org.eclipse.equinox.launcher.cocoa.macosx.x86_64"/>
       <plugin id="org.eclipse.equinox.launcher.gtk.linux.x86_64"/>
       <plugin id="org.eclipse.equinox.launcher.win32.win32.x86_64"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
+      <plugin id="org.eclipse.jetty.ee8.security"/>
+      <plugin id="org.eclipse.jetty.ee8.server"/>
+      <plugin id="org.eclipse.jetty.ee8.servlet"/>
       <plugin id="org.eclipse.jetty.http"/>
       <plugin id="org.eclipse.jetty.io"/>
       <plugin id="org.eclipse.jetty.security"/>
       <plugin id="org.eclipse.jetty.server"/>
-      <plugin id="org.eclipse.jetty.servlet"/>
+      <plugin id="org.eclipse.jetty.servlet-api"/>
+      <plugin id="org.eclipse.jetty.session"/>
       <plugin id="org.eclipse.jetty.util"/>
+      <plugin id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped"/>
       <plugin id="org.eclipse.ltk.core.refactoring"/>
+      <plugin id="org.eclipse.orbit.xml-apis-ext"/>
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state"/>
       <plugin id="org.eclipse.osgi.services"/>
@@ -180,7 +191,10 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.datastore.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.analysis.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.ftrace.core"/>
+      <plugin id="org.eclipse.tracecompass.incubator.gpu.core"/>
+      <plugin id="org.eclipse.tracecompass.incubator.inandout.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.opentracing.core"/>
+      <plugin id="org.eclipse.tracecompass.incubator.rocm.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core"/>
       <plugin id="org.eclipse.tracecompass.incubator.traceevent.core"/>
       <plugin id="org.eclipse.tracecompass.jsontrace.core"/>
@@ -197,25 +211,43 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.tmf.filter.parser"/>
       <plugin id="org.eclipse.tracecompass.trace-event-logger"/>
       <plugin id="org.glassfish.hk2.api"/>
-      <plugin id="org.glassfish.hk2.external.jakarta.inject"/>
       <plugin id="org.glassfish.hk2.locator"/>
       <plugin id="org.glassfish.hk2.osgi-resource-locator"/>
       <plugin id="org.glassfish.hk2.utils"/>
-      <plugin id="org.glassfish.jersey.containers.servlet"/>
-      <plugin id="org.glassfish.jersey.containers.servlet.core"/>
+      <plugin id="org.glassfish.jersey.containers.jersey-container-servlet-core"/>
       <plugin id="org.glassfish.jersey.core.jersey-client"/>
       <plugin id="org.glassfish.jersey.core.jersey-common"/>
       <plugin id="org.glassfish.jersey.core.jersey-server"/>
-      <plugin id="org.glassfish.jersey.ext.entityfiltering"/>
+      <plugin id="org.glassfish.jersey.ext.jersey-entity-filtering"/>
       <plugin id="org.glassfish.jersey.inject.jersey-hk2"/>
-      <plugin id="org.glassfish.jersey.media.jersey-media-jaxb"/>
       <plugin id="org.glassfish.jersey.media.jersey-media-json-jackson"/>
+      <plugin id="org.hamcrest"/>
       <plugin id="org.hamcrest.core"/>
-      <plugin id="org.json"/>
       <plugin id="org.junit"/>
       <plugin id="org.mozilla.javascript"/>
-      <plugin id="org.slf4j.api"/>
+      <plugin id="org.objectweb.asm"/>
+      <plugin id="org.objectweb.asm.commons"/>
+      <plugin id="org.objectweb.asm.tree"/>
+      <plugin id="org.objectweb.asm.tree.analysis"/>
+      <plugin id="org.objectweb.asm.util"/>
+      <plugin id="org.osgi.service.cm"/>
+      <plugin id="org.osgi.service.component"/>
+      <plugin id="org.osgi.service.device"/>
+      <plugin id="org.osgi.service.event"/>
+      <plugin id="org.osgi.service.http.whiteboard"/>
+      <plugin id="org.osgi.service.metatype"/>
+      <plugin id="org.osgi.service.prefs"/>
+      <plugin id="org.osgi.service.provisioning"/>
+      <plugin id="org.osgi.service.upnp"/>
+      <plugin id="org.osgi.service.useradmin"/>
+      <plugin id="org.osgi.service.wireadmin"/>
+      <plugin id="org.osgi.util.function"/>
+      <plugin id="org.osgi.util.measurement"/>
+      <plugin id="org.osgi.util.position"/>
+      <plugin id="org.osgi.util.promise"/>
+      <plugin id="org.osgi.util.xml"/>
       <plugin id="org.yaml.snakeyaml"/>
+      <plugin id="slf4j.api"/>
    </plugins>
 
    <configurations>


### PR DESCRIPTION
### What it does

Create legacy-e4.34/traceserver.product
Remove legacy/traceserver.product

### How to test

To build for 4.34 target:

cp trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy-e4.34/traceserver.product trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product

mvn clean install -DskipTests=true -Dtarget-platform=tracecompass-incubator-e4.34 -Djdk.version=17 -Djdk.release=17

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
