### PR TITLE
server: Validate parent descriptor when creating derived data provider

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderConfigurationServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderConfigurationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Ericsson and others
+ * Copyright (c) 2024, 2025 Ericsson and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -201,7 +201,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         dpCreationEndpoint = getDpCreationEndpoint(exp.getUUID().toString(), UNKNOWN_DP_ID);
         try (Response response = assertDpPostWithErrors(dpCreationEndpoint, configuration)) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(String.class));
         }
 
         // Test config type is not applicable for another data provider

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/DataProviderService.java
@@ -1302,6 +1302,11 @@ public class DataProviderService {
                 return errorResponse;
             }
 
+            IDataProviderDescriptor parentDescriptor = getDescriptor(experiment, outputId);
+            if (parentDescriptor == null) {
+                return Response.status(Status.NOT_FOUND).entity(NO_SUCH_PROVIDER + ": " + outputId).build(); //$NON-NLS-1$
+            }
+
             IDataProviderFactory factory = manager.getFactory(outputId);
             if (factory == null) {
                 return Response.status(Status.NOT_FOUND).entity(NO_SUCH_PROVIDER).build();


### PR DESCRIPTION
### What it does

Validate parent descriptor when creating derived data provider.

This can prevent creating derived providers from hidden data providers.

### How to test

With https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/243, configure the trace-server to hide a data provider configurator.

For example in ~/.tracecompass-webapp/.metadata/.plugins/org.eclipse.tracecompass.tmf.core/dataprovider.ini, add line:

hide:org.eclipse.tracecompass.incubator.inandout.core.analysis.inAndOutdataProviderFactory:*

Then try to create a derived data provider. For example using tsp-python-client:

./tsp_cli_client --create-output org.eclipse.tracecompass.incubator.inandout.core.analysis.inAndOutdataProviderFactory --uuid _uuid_ --json-file _jsonfile_

It should fail with 404 error code (Data provider doesn't exist).

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
