### PR TITLE
Add logging to configurable reports data providers

### DIFF
--- a/callstack/org.eclipse.tracecompass.incubator.analysis.core/src/org/eclipse/tracecompass/incubator/analysis/core/reports/ImageReportDataProvider.java
+++ b/callstack/org.eclipse.tracecompass.incubator.analysis.core/src/org/eclipse/tracecompass/incubator/analysis/core/reports/ImageReportDataProvider.java
@@ -135,6 +135,8 @@ public class ImageReportDataProvider implements IReportDataProvider {
      */
     @SuppressWarnings("null")
     private static IStatus createImage(ITmfTrace trace, ITmfConfiguration configuration) {
+        Activator.getInstance().logInfo("Creating image report configuration " + configuration.getName() + " for trace " + trace.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+
         IPath originalPath = new Path((String) configuration.getParameters().get(PATH));
 
         if (!originalPath.toFile().exists()) {
@@ -182,12 +184,16 @@ public class ImageReportDataProvider implements IReportDataProvider {
                 FileChannel source = fis.getChannel();
                 FileChannel destination = fos.getChannel()) {
             destination.transferFrom(source, 0, source.size());
+            Activator.getInstance().logInfo("Image file copied from " + fromFile.getAbsolutePath() + " to " + toFile.getAbsolutePath() //$NON-NLS-1$ //$NON-NLS-2$
+                    + " of configuration " + configuration.getName() + " for trace " + trace.getName()); //$NON-NLS-1$ //$NON-NLS-2$
         } catch (IOException e) {
             return new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Failed to copy image file", e); //$NON-NLS-1$
         }
 
         // Set the configuration path to the new path
         configuration.getParameters().put(PATH, toFile.getAbsolutePath());
+
+        Activator.getInstance().logInfo("Image report configuration " + configuration.getName() + " for trace " + trace.getName() + " created successfully"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
         return Status.OK_STATUS;
     }
@@ -248,6 +254,9 @@ public class ImageReportDataProvider implements IReportDataProvider {
         if (imageFile.exists() && !imageFile.delete()) {
             throw new TmfConfigurationException("Failed to delete image file"); //$NON-NLS-1$
         }
+
+        Activator.getInstance().logInfo("Image file " + imageFile.getAbsolutePath() + " of configuration " + configuration.getName() //$NON-NLS-1$ //$NON-NLS-2$
+                + " for trace " + trace.getName() + " deleted successfully"); //$NON-NLS-1$ //$NON-NLS-2$
 
         return getDescriptorFromConfig(trace, configuration);
     }

--- a/callstack/org.eclipse.tracecompass.incubator.analysis.core/src/org/eclipse/tracecompass/incubator/analysis/core/reports/ReportsDataProviderFactory.java
+++ b/callstack/org.eclipse.tracecompass.incubator.analysis.core/src/org/eclipse/tracecompass/incubator/analysis/core/reports/ReportsDataProviderFactory.java
@@ -113,6 +113,7 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
     public ReportsDataProviderFactory() {
         TmfSignalManager.register(this);
         ReportsDataProviderRegistry.registerProvider(this);
+        Activator.getInstance().logInfo("Reports data provider factory initialized"); //$NON-NLS-1$
     }
 
     @Override
@@ -207,6 +208,7 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
     @SuppressWarnings("null")
     @Override
     public @NonNull IDataProviderDescriptor createDataProviderDescriptors(@NonNull ITmfTrace trace, @NonNull ITmfConfiguration configuration) throws TmfConfigurationException {
+        Activator.getInstance().logInfo("Creating data provider descriptor for trace: " + trace.getName()); //$NON-NLS-1$ );
         ITmfConfiguration config = validateConfiguration(trace, configuration);
 
         ReportProviderType type = getReportType(config);
@@ -233,6 +235,8 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
 
         writeConfiguration(trace, config);
 
+        Activator.getInstance().logInfo("Created data provider descriptor: " + descriptor.getName() + " for trace: " + trace.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+
         return descriptor;
     }
 
@@ -248,6 +252,8 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
      */
     @Override
     public void removeDataProviderDescriptor(@NonNull ITmfTrace trace, @NonNull IDataProviderDescriptor descriptor) throws TmfConfigurationException {
+        Activator.getInstance().logInfo("Removing data provider descriptor: " + descriptor.getName() + " for trace: " + trace.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+
         ITmfConfiguration config = descriptor.getConfiguration();
         if (config == null) {
             throw new TmfConfigurationException("Data provider was not created by a configuration"); //$NON-NLS-1$
@@ -574,6 +580,8 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
      *             if an error occurs while writing
      */
     private static void writeConfiguration(@NonNull ITmfTrace trace, @NonNull ITmfConfiguration configuration) throws TmfConfigurationException {
+        Activator.getInstance().logInfo("Writing configuration " + configuration.getName() + " for trace " + trace.getName() + " to disk"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
         IPath basePath = getConfigurationBasePath(trace, configuration);
 
         File folder = basePath.toFile();
@@ -595,6 +603,8 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
      *             if an error occurs while removing
      */
     private static void removeConfiguration(@NonNull ITmfTrace trace, @NonNull ITmfConfiguration configuration) throws TmfConfigurationException {
+        Activator.getInstance().logInfo("Removing configuration " + configuration.getName() + " for trace " + trace.getName() + " from disk"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
         IPath configPath = getConfigurationBasePath(trace, configuration);
         File file = configPath.toFile();
 
@@ -724,6 +734,8 @@ public class ReportsDataProviderFactory implements IDataProviderFactory, ITmfDat
 
         fTmfConfigurationTable.clear();
         fTmfConfigurationHierarchy.clear();
+
+        Activator.getInstance().logInfo("Reports data provider factory disposed"); //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
### What it does

Considering potential security issues, multiple logging statements have been introduced in this commit in the configurable reports data provider classes, enabling comprehensive monitoring of significant actions taken by the users. The logging implementation tracks key operations such as configuration creation, removal, as well as file system interactions and trace management activities. 

### How to test

The stored logs for the `org.eclipse.tracecompass.incubator.analysis.core` bundle may be analyzed to verify the presence of logs of the two `ReportsDataProviderFactory` and `ImageReportDataProvider` classes.

### Follow-ups

In case of more requiring more detail analysis, further logging statements may be introduced.

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
