### PR TITLE
inandout: Fix errors in JSON schema

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/schema/in-and-out-analysis.json
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/schema/in-and-out-analysis.json
@@ -34,18 +34,18 @@
                     "classifier": {
                      "type": "string",
                      "description": "The classifier"
-                    },
-                    "required": [
-                        "label",
-                        "inRegex",
-                        "outRegex",
-                        "contextInRegex",
-                        "contextOutRegex",
-                        "classifier"
-                    ]
-               }
+                    }
+                },
+                "required": [
+                    "label",
+                    "inRegex",
+                    "outRegex",
+                    "contextInRegex",
+                    "contextOutRegex",
+                    "classifier"
+                ]
             }
         }
     },
-    "required": ["name", "specifiers"]
+    "required": ["specifiers"]
 }


### PR DESCRIPTION
### What it does

Remove required name in schema. The name is required by TSP protocol but is not part of the schema's
properties object.

The 'required' attribute should be outside the properties object.

### How to test

Validate a JSON configuration without name field inside properties/parameters object.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
