### PR TITLE
releng: fix unknown extended header keyword 'LIBARCHIVE.creationtime'

### DIFF
--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/pom.xml
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/pom.xml
@@ -49,6 +49,7 @@
                                 <solaris>zip</solaris>
                                 <win32>zip</win32>
                             </formats>
+                            <storeCreationTime>false</storeCreationTime>
                         </configuration>
                     </execution>
                 </executions>

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/pom.xml
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/pom.xml
@@ -49,6 +49,7 @@
                                 <solaris>zip</solaris>
                                 <win32>zip</win32>
                             </formats>
+                            <storeCreationTime>false</storeCreationTime>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

This warning shows when extracting the RCP on Linux because GNU tar doesn't support that attribute.

The creating time is part of the tarfile name.

Apply this for Trace Compass RCP and Trace Server RCP.

See here for details about the setting:
https://tycho.eclipseprojects.io/doc/4.0.10/tycho-p2-director-plugin/archive-products-mojo.html#storeCreationTime

Eclipse platform has it disabled as well.
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/master/eclipse-platform-parent/pom.xml

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Build the RCP and trace server, and untar the archives on Linux.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
