### PR TITLE
swagger: Use requested_timerange in TreeQueryParameters

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeQueryParameters.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Ericsson
+ * Copyright (c) 2021, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -34,7 +34,7 @@ public interface TreeQueryParameters {
      */
     interface TreeParameters {
 
-        @JsonProperty("requested_times")
-        long[] getRequestedTimes();
+        @JsonProperty("requested_timerange")
+        TimeRange getRequestedTimeRange();
     }
 }


### PR DESCRIPTION
### What it does

Replace requested_times with requested_timerange. This aligns with the description of the endpoints that use this parameter.

### How to test

Generate TSP documentation. Look for the definition of parameters in the timegraph tree, XY tree and data tree endpoints.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
