### PR TITLE
swagger: Fix type of style values for OutputElementStyle

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputElementStyle.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputElementStyle.java
@@ -39,6 +39,14 @@ public interface OutputElementStyle {
      */
     @Schema(description = "Style values or empty map if there are no values. " +
             "Keys and values are defined in " +
-            "https://git.eclipse.org/r/plugins/gitiles/tracecompass/org.eclipse.tracecompass/+/refs/heads/master/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java")
-    Map<String, Object> getValues();
+            "https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/blob/master/tmf/org.eclipse.tracecompass.tmf.core/src/org/eclipse/tracecompass/tmf/core/model/StyleProperties.java")
+    Map<String, StyleValue> getValues();
+
+    /**
+     * Type for style values (String, Float, Integer or Boolean)
+     */
+    @Schema(description = "Supported types of a style value.", oneOf = { String.class, Float.class, Integer.class, Boolean.class })
+    interface StyleValue {
+        // empty
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Allow only certain data types for style values.

Fixes:
https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/102

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

[Generate openapi.yaml file](https://github.com/eclipse-cdt-cloud/trace-server-protocol?tab=readme-ov-file#generate-the-api) and verify changes fixes the reference bug in the TSP.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups
None

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
