### PR TITLE
swagger: Document meaning of value -1 for parentId of TreeDataModel

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeDataModel.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeDataModel.java
@@ -28,14 +28,13 @@ public interface TreeDataModel {
     /**
      * @return The ID.
      */
-    @Schema(description = "Unique id to identify this entry in the backend", required = true)
+    @Schema(description = "Unique ID to identify this entry in the backend", required = true)
     long getId();
 
     /**
      * @return The parent ID.
      */
-    @Schema(description = "Unique id to identify this parent's entry, " +
-            "optional if this entry does not have a parent.")
+    @Schema(description = "Optional unique ID to identify this entry's parent. If the parent ID is -1 or omitted, this entry has no parent.")
     long getParentId();
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Document meaning of value -1 for parentId of TreeDataModel in swagger model.

Fixes https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/65

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Generate openapi.yaml and verify change is there.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

Update TSP specification 

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
