### PR TITLE
Add entry-tree parameter to collapse children

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/EntryModelStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/EntryModelStub.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -36,6 +36,7 @@ public class EntryModelStub implements Serializable {
 
     private final List<EntryStub> fEntries;
     private final List<EntryHeaderStub> fHeaders;
+    private final int fAutoExpandLevel;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -44,12 +45,16 @@ public class EntryModelStub implements Serializable {
      *            The set of entries for this model
      * @param headers
      *            The set of headers for this model
+     * @param autoExpandLevel
+     *            The auto-expand level for this model
      */
     @JsonCreator
     public EntryModelStub(@JsonProperty("entries") List<EntryStub> entries,
-            @JsonProperty("headers") List<EntryHeaderStub> headers) {
+            @JsonProperty("headers") List<EntryHeaderStub> headers,
+            @JsonProperty("autoExpandLevel") Integer autoExpandLevel) {
         fEntries = Objects.requireNonNull(entries, "The 'entries' json field was not set");
         fHeaders = headers == null ? Collections.emptyList() : headers;
+        fAutoExpandLevel = autoExpandLevel == null ? -1 : autoExpandLevel;
     }
 
     /**
@@ -68,6 +73,15 @@ public class EntryModelStub implements Serializable {
      */
     public List<EntryHeaderStub> getHeaders() {
         return fHeaders;
+    }
+
+    /**
+     * Get the auto-expand level
+     *
+     * @return auto-expand level
+     */
+    public int getAutoExpandLevel() {
+        return fAutoExpandLevel;
     }
 
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TgEntryModelStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TgEntryModelStub.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal and others
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -36,6 +36,7 @@ public class TgEntryModelStub implements Serializable {
 
     private final Set<TimeGraphEntryStub> fEntries;
     private final Set<EntryHeaderStub> fHeaders;
+    private final int fAutoExpandLevel;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -44,12 +45,16 @@ public class TgEntryModelStub implements Serializable {
      *            The set of entries for this model
      * @param headers
      *            The set of headers for this model
+     * @param autoExpandLevel
+     *            The auto-expand level for this model
      */
     @JsonCreator
     public TgEntryModelStub(@JsonProperty("entries") Set<TimeGraphEntryStub> entries,
-            @JsonProperty("headers") Set<EntryHeaderStub> headers) {
+            @JsonProperty("headers") Set<EntryHeaderStub> headers,
+            @JsonProperty("autoExpandLevel") Integer autoExpandLevel) {
         fEntries = Objects.requireNonNull(entries, "The 'entries' json field was not set");
         fHeaders = headers == null ? Collections.emptySet() : headers;
+        fAutoExpandLevel = autoExpandLevel == null ? -1 : autoExpandLevel;
     }
 
     /**
@@ -70,4 +75,12 @@ public class TgEntryModelStub implements Serializable {
         return fHeaders;
     }
 
+    /**
+     * Get the auto-expand level
+     *
+     * @return auto-expand level
+     */
+    public int getAutoExpandLevel() {
+        return fAutoExpandLevel;
+    }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/XyEntryModelStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/XyEntryModelStub.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2023 Ericsson
+ * Copyright (c) 2023, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -32,6 +32,7 @@ public class XyEntryModelStub implements Serializable {
 
     private final List<XyEntryStub> fEntries;
     private final List<EntryHeaderStub> fHeaders;
+    private final int fAutoExpandLevel;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -40,12 +41,16 @@ public class XyEntryModelStub implements Serializable {
      *            The set of entries for this model
      * @param headers
      *            The set of headers for this model
+     * @param autoExpandLevel
+     *            The auto-expand level for this model
      */
     @JsonCreator
     public XyEntryModelStub(@JsonProperty("entries") List<XyEntryStub> entries,
-            @JsonProperty("headers") List<EntryHeaderStub> headers) {
+            @JsonProperty("headers") List<EntryHeaderStub> headers,
+            @JsonProperty("autoExpandLevel") Integer autoExpandLevel) {
         fEntries = Objects.requireNonNull(entries, "The 'entries' json field was not set");
         fHeaders = headers == null ? Collections.emptyList() : headers;
+        fAutoExpandLevel = autoExpandLevel == null ? -1 : autoExpandLevel;
     }
 
     /**
@@ -64,5 +69,14 @@ public class XyEntryModelStub implements Serializable {
      */
     public List<EntryHeaderStub> getHeaders() {
         return fHeaders;
+    }
+
+    /**
+     * Get the auto-expand level
+     *
+     * @return auto-expand level
+     */
+    public int getAutoExpandLevel() {
+        return fAutoExpandLevel;
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeEntryModel.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TreeEntryModel.java
@@ -34,4 +34,14 @@ public interface TreeEntryModel {
      */
     @NonNull
     List<@NonNull TreeColumnHeader> getHeaders();
+
+    /**
+     * @return The auto-expand level.
+     */
+    @Schema(description = "Sets the auto-expand level to be used for the input of the tree. The "
+            + "value 0 means that there is no auto-expand; 1 means that top-level "
+            + "elements are expanded, but not their children; 2 means that top-level "
+            + "elements are expanded, and their children, but not grand-children; and so "
+            + "on. The value -1 means that all subtrees should be expanded.")
+    int getAutoExpandLevel();
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TreeModelWrapper.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/TreeModelWrapper.java
@@ -114,4 +114,12 @@ public class TreeModelWrapper {
         return fModel.getEntries();
     }
 
+    /**
+     * Wrapper to the {@link TmfTreeModel#getAutoExpandLevel()} method
+     *
+     * @return Indicates till which level of the tree we should expand the nodes
+     */
+    public int getAutoExpandLevel() {
+        return fModel.getAutoExpandLevel();
+    }
 }


### PR DESCRIPTION
### What it does


swagger: Add auto-expand level to TreeEntryModel
server: Add serialization of auto-expand level for tree models

tmf: Add auto-expand level in TmfTreeModel

### How to test

Run updated unit tests.

### Follow-ups

Related incubator PR.
https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/pull/196

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template

Signed-off-by: Hriday Panchasara <hriday.panchasara@ericsson.com>
Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

