### PR TITLE
releng: Upgrade target to dependencies of 2025-06 (Eclipse 4.36) release

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderConfigurator.java
+++ b/analyses/org.eclipse.tracecompass.incubator.inandout.core/src/org/eclipse/tracecompass/incubator/internal/inandout/core/analysis/InAndOutDataProviderConfigurator.java
@@ -154,11 +154,10 @@ public class InAndOutDataProviderConfigurator extends TmfComponent implements IT
         }
 
         String configId = creationConfiguration.getId();
-        ITmfConfiguration config = fTmfConfigurationTable.get(configId, trace);
-        if (config == null) {
+        if (!fTmfConfigurationTable.contains(configId, trace)) {
             return;
         }
-        config = fTmfConfigurationTable.remove(configId, trace);
+        ITmfConfiguration config = fTmfConfigurationTable.remove(configId, trace);
         removeConfiguration(trace, config);
     }
 

--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="84">
+<target name="tracecompass-incubator-master" sequenceNumber="85">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -13,13 +13,13 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/releases/12.0/cdt-12.0.0/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtbot.generator.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/technology/swtbot/releases/4.2.1/"/>
+<repository location="https://download.eclipse.org/technology/swtbot/releases/4.3.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="bcpg" version="0.0.0"/>
@@ -40,7 +40,7 @@
 <unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0"/>
 <unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations.source" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
-<unit id="com.google.guava" version="33.4.0.jre"/>
+<unit id="com.google.guava" version="33.4.8.jre"/>
 <unit id="com.sun.xml.bind.jaxb-osgi" version="2.3.9"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
@@ -61,7 +61,6 @@
 <unit id="org.apache.commons.commons-compress" version="0.0.0"/>
 <unit id="org.apache.commons.commons-io" version="0.0.0"/>
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-<unit id="org.apache.commons.jxpath" version="0.0.0"/>
 <unit id="org.apache.commons.lang" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
 <unit id="org.apache.commons.math3" version="0.0.0"/>
@@ -90,7 +89,7 @@
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.36.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -118,17 +117,17 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.35/R-4.35-202502280140/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.36/R-4.36-202505281830/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.37.0/R-3.37.0-20250303081219/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.38.0/R-3.38.0-20250601070120/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.41.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.42.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
@@ -258,7 +257,7 @@
 			<dependency>
 				<groupId>org.eclipse.tracecompass</groupId>
 				<artifactId>trace-event-logger</artifactId>
-				<version>0.4.0</version>
+				<version>0.5.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
@@ -134,11 +134,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.antlr.runtime"/>
       <plugin id="org.aopalliance"/>
       <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
-      <plugin id="org.apache.commons.collections"/>
-      <plugin id="org.apache.commons.commons-beanutils"/>
       <plugin id="org.apache.commons.commons-logging"/>
       <plugin id="org.apache.commons.commons-io"/>
-      <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.lang3"/>
       <plugin id="org.apache.felix.gogo.command"/>
       <plugin id="org.apache.felix.gogo.runtime"/>
@@ -231,7 +228,6 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.glassfish.jersey.media.jersey-media-json-jackson"/>
       <plugin id="org.hamcrest"/>
       <plugin id="org.hamcrest.core"/>
-      <plugin id="org.jdom"/>
       <plugin id="org.junit"/>
       <plugin id="org.mozilla.javascript"/>
       <plugin id="org.objectweb.asm"/>


### PR DESCRIPTION
### What it does

releng: Upgrade target to dependencies of 2025-06 (Eclipse 4.36) release

### How to test

Build with target

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
