### PR TITLE
Add generic xy endpoint in the server

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/GenericXYDataProviderServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/GenericXYDataProviderServiceTest.java
@@ -1,0 +1,282 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson and others
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.QueryParameters;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.DataProviderService;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.EntryStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.ExperimentModelStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.IAxisDomainStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XyEntryModelStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XyEntryStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XyTreeOutputResponseStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.ISamplingStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.TmfXYAxisDescriptionStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XyModelStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XyOutputResponseStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.XySeriesStub;
+import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.utils.RestServerTest;
+import org.eclipse.tracecompass.internal.tmf.core.Activator;
+import org.eclipse.tracecompass.tmf.core.model.StyleProperties;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test {@link DataProviderService} with generic xy endpoints with non-time x-axis.
+ *
+ * @author Siwei Zhang
+ */
+@SuppressWarnings({"null"})
+public class GenericXYDataProviderServiceTest extends RestServerTest {
+    private static final String DATA_PROVIDER_RESPONSE_FAILED_MSG = "There should be a positive response for the data provider";
+    private static final String MODEL_NULL_MSG = "The model is null, maybe the analysis did not run long enough?";
+    private static final String REQUESTED_ITEMS_KEY = "requested_items";
+    private static final String REQUESTED_TIMERANGE_KEY = "requested_timerange";
+    private static final String START = "start";
+    private static final String END = "end";
+    private static final String NB_SAMPLES = "nbSamples";
+    private static final int MAX_ITER = 40;
+    private static final long TRACE_START_TIME = 1450193697034689597L;
+    private static final long TRACE_END_TIME = 1450193745774189602L;
+    private static final List<XyEntryStub> EXPECTED_ENTRIES = List.of(
+            new XyEntryStub(Arrays.asList("ust"), 0, -1, true, null, true),
+            new XyEntryStub(Arrays.asList("UNKNOWN_PID"), 1, 0, true, null, false));
+
+    /**
+     * Ensure that a generic xy data provider exists and returns correct data.
+     * It does not test the data itself, simply that the serialized fields are
+     * the expected ones according to the protocol. Tested using generic xy
+     * provider for call stack.
+     *
+     * @throws InterruptedException
+     *             Exception thrown while waiting to execute again
+     */
+    @Test
+    public void testGenericXYDataProvider() throws InterruptedException {
+        ExperimentModelStub exp = assertPostExperiment(sfContextSwitchesUstNotInitializedStub.getName(), sfContextSwitchesUstNotInitializedStub);
+
+        WebTarget callstackTree = getGenericXYTreeEndpoint(exp.getUUID().toString(), CALL_STACK_FUNCTION_DENSITY_DATAPROVIDER_ID);
+
+        // Test getting the tree endpoint with descriptors
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(REQUESTED_TIMES_KEY, List.of(0L, Long.MAX_VALUE));
+        XyTreeOutputResponseStub responseModel;
+        try (Response tree = callstackTree.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+            assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, tree.getStatus());
+            responseModel = tree.readEntity(XyTreeOutputResponseStub.class);
+            assertNotNull(responseModel);
+        }
+        // Make sure the analysis ran enough and we have a model
+        int iteration = 0;
+        while (responseModel.isRunning() && responseModel.getModel() == null && iteration < MAX_ITER) {
+            Thread.sleep(100);
+            try (Response treeResponse = callstackTree.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+                assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, treeResponse.getStatus());
+                responseModel = treeResponse.readEntity(XyTreeOutputResponseStub.class);
+                assertNotNull(responseModel);
+                iteration++;
+            }
+        }
+
+        // Validate model
+        XyEntryModelStub model = responseModel.getModel();
+        assertNotNull(MODEL_NULL_MSG + responseModel, model);
+
+        List<XyEntryStub> entries = model.getEntries();
+        assertFalse(entries.isEmpty());
+
+        // Test getting the generic xy endpoint with descriptors for xy
+        WebTarget xyEnpoint = getGenericXYSeriesEndpoint(exp.getUUID().toString(), CALL_STACK_FUNCTION_DENSITY_DATAPROVIDER_ID);
+        parameters = new HashMap<>();
+        List<Integer> items = new ArrayList<>();
+        for (EntryStub entry : entries) {
+            items.add(entry.getId());
+        }
+        parameters.put(REQUESTED_ITEMS_KEY, items);
+        parameters.put(REQUESTED_TIMERANGE_KEY, ImmutableMap.of(START, TRACE_START_TIME, END, TRACE_END_TIME, NB_SAMPLES, 5));
+        try (Response series = xyEnpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+            assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, series.getStatus());
+            XyOutputResponseStub xyModelResponse = series.readEntity(XyOutputResponseStub.class);
+            assertNotNull(xyModelResponse);
+
+            XyModelStub xyModel = xyModelResponse.getModel();
+            Set<XySeriesStub> xySeries = xyModel.getSeries();
+            assertFalse(xySeries.isEmpty());
+        }
+    }
+
+    /**
+     * Ensure that the inside data is correct for call stack function density
+     * data provider for both tree end point and xy end point.
+     *
+     * @throws InterruptedException
+     *             Exception thrown while waiting to execute again
+     */
+    @Test
+    public void testCallStackFunctionDensityDataProvider() throws InterruptedException {
+        ExperimentModelStub exp = assertPostExperiment(sfContextSwitchesUstNotInitializedStub.getName(), sfContextSwitchesUstNotInitializedStub);
+
+        WebTarget callstackTree = getGenericXYTreeEndpoint(exp.getUUID().toString(), CALL_STACK_FUNCTION_DENSITY_DATAPROVIDER_ID);
+
+        /*
+         * Test the data in the tree end point with descriptors.
+         */
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(REQUESTED_TIMES_KEY, List.of(0L, Long.MAX_VALUE));
+        XyTreeOutputResponseStub responseModel;
+        try (Response tree = callstackTree.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+            assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, tree.getStatus());
+            responseModel = tree.readEntity(XyTreeOutputResponseStub.class);
+            assertNotNull(responseModel);
+        }
+        // Make sure the analysis ran enough and we have a model
+        int iteration = 0;
+        while (responseModel.isRunning() && responseModel.getModel() == null && iteration < MAX_ITER) {
+            Thread.sleep(100);
+            try (Response treeResponse = callstackTree.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+                assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, treeResponse.getStatus());
+                responseModel = treeResponse.readEntity(XyTreeOutputResponseStub.class);
+                assertNotNull(responseModel);
+                iteration++;
+            }
+        }
+
+        // Validate model
+        XyEntryModelStub model = responseModel.getModel();
+        assertNotNull(MODEL_NULL_MSG + responseModel, model);
+
+        int autoExpandLevel = model.getAutoExpandLevel();
+        assertEquals("Auto-expand level mismatch", -1, autoExpandLevel);
+
+        // Entries
+        List<XyEntryStub> actualEntries = model.getEntries();
+        assertEquals("Entry count mismatch", EXPECTED_ENTRIES.size(), actualEntries.size());
+
+        for (int i = 0; i < EXPECTED_ENTRIES.size(); i++) {
+            XyEntryStub expected = EXPECTED_ENTRIES.get(i);
+            XyEntryStub actual = actualEntries.get(i);
+            assertEquals("HasRowModel mismatch at index " + i, expected.hasRowModel(), actual.hasRowModel());
+            assertEquals("Labels mismatch at index " + i, expected.getLabels(), actual.getLabels());
+            assertEquals("Style mismatch at index " + i, expected.getStyle(), actual.getStyle());
+        }
+        assertEquals("Parent-child id mismatch.", actualEntries.get(0).getId(), actualEntries.get(1).getParentId());
+
+        /*
+         * Test the data in xy end point.
+         */
+        WebTarget xyEnpoint = getGenericXYSeriesEndpoint(exp.getUUID().toString(), CALL_STACK_FUNCTION_DENSITY_DATAPROVIDER_ID);
+        parameters = new HashMap<>();
+        List<Integer> items = new ArrayList<>();
+        for (EntryStub entry : actualEntries) {
+            items.add(entry.getId());
+        }
+        parameters.put(REQUESTED_ITEMS_KEY, items);
+        parameters.put(REQUESTED_TIMERANGE_KEY, ImmutableMap.of(START, TRACE_START_TIME, END, TRACE_END_TIME, NB_SAMPLES, 5));
+        XyOutputResponseStub xyModelResponse;
+        try (Response series = xyEnpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+            assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, series.getStatus());
+            xyModelResponse = series.readEntity(XyOutputResponseStub.class);
+        }
+        assertNotNull(xyModelResponse);
+        // Make sure the analysis ran enough and we have a fully executed model
+        iteration = 0;
+        while (xyModelResponse.isRunning() && iteration < MAX_ITER) {
+            Thread.sleep(100);
+            try (Response response = xyEnpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
+                Activator.logWarning("current status: " + xyModelResponse.isRunning());
+                assertEquals(DATA_PROVIDER_RESPONSE_FAILED_MSG, 200, response.getStatus());
+                xyModelResponse = response.readEntity(XyOutputResponseStub.class);
+                assertNotNull(xyModelResponse);
+                iteration++;
+            }
+        }
+        XyModelStub xyModel = xyModelResponse.getModel();
+        Set<XySeriesStub> xySeries = xyModel.getSeries();
+        assertEquals("Number of series mismatch", 1, xySeries.size());
+        XySeriesStub seriesStub = xySeries.iterator().next();
+
+        // Validate fields
+        assertEquals("Name mismatch", "UNKNOWN_PID", seriesStub.getName());
+
+        // Validate xValues
+        ISamplingStub xValues = seriesStub.getXValues();
+        assertTrue("xValues should be a RangesStub", xValues instanceof ISamplingStub.RangesStub);
+        List<ISamplingStub.RangesStub.RangeStub> expectedRanges = Arrays.asList(
+                new ISamplingStub.RangesStub.RangeStub(0L, 1195708549L),
+                new ISamplingStub.RangesStub.RangeStub(1195708550L, 2391417098L),
+                new ISamplingStub.RangesStub.RangeStub(2391417099L, 3587125647L),
+                new ISamplingStub.RangesStub.RangeStub(3587125648L, 4782834196L),
+                new ISamplingStub.RangesStub.RangeStub(4782834197L, 5978542746L)
+            );
+        List<ISamplingStub.RangesStub.RangeStub> actualRanges = ((ISamplingStub.RangesStub) xValues).getRanges();
+        assertEquals("Range size mismatch", expectedRanges.size(), actualRanges.size());
+        assertEquals("Range size mismatch", expectedRanges.size(), actualRanges.size());
+        for (int i = 0; i < expectedRanges.size(); i++) {
+            assertEquals("Range mismatch at index " + i, expectedRanges.get(i), actualRanges.get(i));
+        }
+
+        // Validate yValues
+        List<Double> actualYValues = seriesStub.getYValues();
+        List<Double> expectedYValues = Arrays.asList(1943.0, 1.0, 2.0, 1.0, 1.0);
+        assertEquals("Y values size mismatch", expectedYValues.size(), actualYValues.size());
+        assertEquals("Y values size mismatch", expectedYValues.size(), actualYValues.size());
+        for (int i = 0; i < expectedYValues.size(); i++) {
+            assertEquals("Y value mismatch at index " + i, expectedYValues.get(i), actualYValues.get(i), 0.000001);
+        }
+
+        // Validate axis descriptions (fully)
+        TmfXYAxisDescriptionStub xAxis = seriesStub.getXAxisDescription();
+        TmfXYAxisDescriptionStub yAxis = seriesStub.getYAxisDescription();
+
+        assertNotNull("X axis description should not be null", xAxis);
+        assertNotNull("Y axis description should not be null", yAxis);
+
+        // X axis
+        assertEquals("X axis label mismatch", "Execution Time", xAxis.getLabel());
+        assertEquals("X axis unit mismatch", "ns", xAxis.getUnit());
+        assertEquals("X axis data type mismatch", "DURATION", xAxis.getDataType());
+        IAxisDomainStub xDomain = xAxis.getAxisDomain();
+        assertNotNull("X axis domain should not be null", xDomain);
+        assertTrue("X axis domain should be TimeRange", xDomain instanceof IAxisDomainStub.RangeStub);
+
+        // Y axis
+        assertEquals("Y axis label mismatch", "Number of Executions", yAxis.getLabel());
+        assertEquals("Y axis unit mismatch", "", yAxis.getUnit());
+        assertEquals("Y axis data type mismatch", "NUMBER", yAxis.getDataType());
+        IAxisDomainStub yDomain = yAxis.getAxisDomain();
+        assertNull("Y axis domain should be null", yDomain);
+
+        // Validate style
+        assertNotNull("Style should not be null", seriesStub.getStyle());
+        assertEquals("Series type should be bar", "bar",
+                seriesStub.getStyle().getStyleValues().get(StyleProperties.SERIES_TYPE));
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/IAxisDomainStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/IAxisDomainStub.java
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * A stub interface for AxisDomain which can be either Categorical or TimeRange.
+ * Matches the trace server protocol schema for <code>AxisDomain</code>.
+ *
+ * @author Siwei Zhang
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = IAxisDomainStub.CategoricalStub.class, name = "categorical"),
+    @JsonSubTypes.Type(value = IAxisDomainStub.RangeStub.class, name = "timeRange")
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public sealed interface IAxisDomainStub extends Serializable permits
+        IAxisDomainStub.CategoricalStub,
+        IAxisDomainStub.RangeStub {
+
+    /**
+     * Stub for AxisDomain.Categorical
+     */
+    final class CategoricalStub implements IAxisDomainStub {
+
+        private static final long serialVersionUID = 2L;
+
+        private final List<String> fCategories;
+
+        /**
+         * Constructor
+         *
+         * @param categories
+         *            the set of category labels for the axis domain
+         */
+        @JsonCreator
+        public CategoricalStub(@JsonProperty("categories") List<String> categories) {
+            fCategories = categories == null ? Collections.emptyList() : categories;
+        }
+
+        /**
+         * Get the categories for this categorical axis domain.
+         *
+         * @return the set of category labels
+         */
+        public List<String> getCategories() {
+            return fCategories;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof CategoricalStub other &&
+                   Objects.equals(fCategories, other.fCategories);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fCategories);
+        }
+
+        @Override
+        public String toString() {
+            return "CategoricalStub{" + "categories=" + fCategories + '}';
+        }
+    }
+
+    /**
+     * Stub for AxisDomain.Range
+     */
+    final class RangeStub implements IAxisDomainStub {
+
+        private static final long serialVersionUID = 3L;
+
+        private final long fStart;
+        private final long fEnd;
+
+        /**
+         * Constructor
+         *
+         * @param start
+         *            start of the time range
+         * @param end
+         *            end of the time range
+         */
+        @JsonCreator
+        public RangeStub(@JsonProperty("start") long start,
+                         @JsonProperty("end") long end) {
+            fStart = start;
+            fEnd = end;
+        }
+
+        /**
+         * Get the start of range.
+         *
+         * @return the start
+         */
+        public long getStart() {
+            return fStart;
+        }
+
+        /**
+         * Get the end of range.
+         *
+         * @return the end
+         */
+        public long getEnd() {
+            return fEnd;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return obj instanceof RangeStub other &&
+                   fStart == other.fStart &&
+                   fEnd == other.fEnd;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fStart, fEnd);
+        }
+
+        @Override
+        public String toString() {
+            return "RangeStub{" + "start=" + fStart + ", end=" + fEnd + '}';
+        }
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ISamplingStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ISamplingStub.java
@@ -1,0 +1,195 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.tracecompass.tmf.core.model.ISampling;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Stub version of {@link ISampling}.
+ *
+ * @author Siwei Zhang
+ */
+@JsonSerialize(using = SamplingStubSerializer.class)
+@JsonDeserialize(using = SamplingStubDeserializer.class)
+public sealed interface ISamplingStub extends Serializable permits
+        ISamplingStub.TimestampsStub,
+        ISamplingStub.CategoriesStub,
+        ISamplingStub.RangesStub {
+
+    /**
+     * Get the number of sampling points
+     *
+     * @return number of points
+     */
+    int size();
+
+    /**
+     * Timestamp-based sampling.
+     */
+    final class TimestampsStub implements ISamplingStub {
+        private static final long serialVersionUID = -8242136490356720296L;
+
+        private final long[] fTimestamps;
+
+        public TimestampsStub(long[] timestamps) {
+            this.fTimestamps = Objects.requireNonNull(timestamps);
+        }
+
+        public long[] getTimestamps() {
+            return fTimestamps;
+        }
+
+        @Override
+        public int size() {
+            return fTimestamps.length;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return (this == obj) || (obj instanceof TimestampsStub other &&
+                    Arrays.equals(this.fTimestamps, other.fTimestamps));
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(fTimestamps);
+        }
+
+        @Override
+        public String toString() {
+            return "Timestamps" + Arrays.toString(fTimestamps); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Categorical sampling (e.g., names).
+     */
+    final class CategoriesStub implements ISamplingStub {
+        private static final long serialVersionUID = 3751152643508688051L;
+
+        private final List<String> fCategories;
+
+        public CategoriesStub(List<String> categories) {
+            this.fCategories = Objects.requireNonNull(categories);
+        }
+
+        public List<String> getCategories() {
+            return fCategories;
+        }
+
+        @Override
+        public int size() {
+            return fCategories.size();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return (this == obj) || (obj instanceof CategoriesStub other &&
+                    Objects.equals(this.fCategories, other.fCategories));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fCategories);
+        }
+
+        @Override
+        public String toString() {
+            return "Categories" + fCategories.toString(); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Range sampling, representing start-end pairs.
+     */
+    final class RangesStub implements ISamplingStub {
+        private static final long serialVersionUID = 3434126540189939098L;
+
+        private final List<RangeStub> fRanges;
+
+        public RangesStub(List<RangeStub> ranges) {
+            this.fRanges = Objects.requireNonNull(ranges);
+        }
+
+        public List<RangeStub> getRanges() {
+            return fRanges;
+        }
+
+        @Override
+        public int size() {
+            return fRanges.size();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            return (this == obj) || (obj instanceof RangesStub other &&
+                    Objects.equals(this.fRanges, other.fRanges));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(fRanges);
+        }
+
+        @Override
+        public String toString() {
+            return "Ranges" + fRanges.toString(); //$NON-NLS-1$
+        }
+
+        /**
+         * Stub representing a range.
+         */
+        public static final class RangeStub implements Serializable {
+            private static final long serialVersionUID = 1L;
+
+            private final long fStart;
+            private final long fEnd;
+
+            public RangeStub(long start, long end) {
+                this.fStart = start;
+                this.fEnd = end;
+            }
+
+            public long getStart() {
+                return fStart;
+            }
+
+            public long getEnd() {
+                return fEnd;
+            }
+
+            @Override
+            public boolean equals(@Nullable Object obj) {
+                return (this == obj) || (obj instanceof RangeStub other &&
+                        fStart == other.fStart && fEnd == other.fEnd);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(fStart, fEnd);
+            }
+
+            @Override
+            public String toString() {
+                return "[" + fStart + ", " + fEnd + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            }
+        }
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/SamplingStubDeserializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/SamplingStubDeserializer.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson and others
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * Deserializer for SamplingStub.
+ *
+ * @author Siwei Zhang
+ */
+public class SamplingStubDeserializer extends JsonDeserializer<ISamplingStub> {
+
+    @Override
+    public ISamplingStub deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.getCurrentToken();
+        if (token != JsonToken.START_ARRAY) {
+            ctxt.reportInputMismatch(ISamplingStub.class, "Expected array for SamplingStub");
+        }
+
+        token = p.nextToken();
+        if (token == JsonToken.VALUE_NUMBER_INT) {
+            List<Long> timestamps = new ArrayList<>();
+            do {
+                timestamps.add(p.getLongValue());
+            } while (p.nextToken() != JsonToken.END_ARRAY);
+            long[] ts = timestamps.stream().mapToLong(Long::longValue).toArray();
+            return new ISamplingStub.TimestampsStub(ts);
+
+        } else if (token == JsonToken.VALUE_STRING) {
+            List<String> categories = new ArrayList<>();
+            do {
+                categories.add(p.getText());
+            } while (p.nextToken() != JsonToken.END_ARRAY);
+            return new ISamplingStub.CategoriesStub(categories);
+
+        } else if (token == JsonToken.START_ARRAY) {
+            List<ISamplingStub.RangesStub.RangeStub> ranges = new ArrayList<>();
+            while (token != JsonToken.END_ARRAY) {
+                p.nextToken(); // start
+                long start = p.getLongValue();
+                p.nextToken(); // end
+                long end = p.getLongValue();
+                p.nextToken(); // end of inner array
+                ranges.add(new ISamplingStub.RangesStub.RangeStub(start, end));
+                token = p.nextToken(); // next outer token
+            }
+            return new ISamplingStub.RangesStub(ranges);
+        }
+
+        ctxt.reportInputMismatch(ISamplingStub.class, "Unrecognized structure for SamplingStub");
+        return null;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/SamplingStubSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/SamplingStubSerializer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson and others
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Serializer for SamplingStub. Matches the protocol format used in real
+ * {@link SamplingStubSerializer}
+ *
+ * @author Siwei Zhang
+ */
+public class SamplingStubSerializer extends StdSerializer<ISamplingStub> {
+
+    private static final long serialVersionUID = 1L;
+
+    public SamplingStubSerializer() {
+        super(ISamplingStub.class);
+    }
+
+    @Override
+    public void serialize(ISamplingStub value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (value instanceof ISamplingStub.TimestampsStub timestamps) {
+            gen.writeArray(timestamps.getTimestamps(), 0, timestamps.getTimestamps().length);
+
+        } else if (value instanceof ISamplingStub.CategoriesStub categories) {
+            gen.writeStartArray();
+            for (String category : categories.getCategories()) {
+                gen.writeString(category);
+            }
+            gen.writeEndArray();
+
+        } else if (value instanceof ISamplingStub.RangesStub ranges) {
+            gen.writeStartArray();
+            for (ISamplingStub.RangesStub.RangeStub range : ranges.getRanges()) {
+                gen.writeStartArray();
+                gen.writeNumber(range.getStart());
+                gen.writeNumber(range.getEnd());
+                gen.writeEndArray();
+            }
+            gen.writeEndArray();
+
+        } else {
+            throw new IllegalArgumentException("Unknown SamplingStub type: " + value.getClass().getName());
+        }
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TmfXYAxisDescriptionStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TmfXYAxisDescriptionStub.java
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A stub class for the XY axis description model. It matches the trace server
+ * protocol's <code>TmfXYAxisDescription</code> schema.
+ *
+ * @author Siwei Zhang
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TmfXYAxisDescriptionStub implements Serializable {
+
+    private static final long serialVersionUID = 7302486196351034579L;
+
+    private final String fLabel;
+    private final String fUnit;
+    private final String fDataType;
+    private final @Nullable IAxisDomainStub fAxisDomain;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param label
+     *            Label for the axis
+     * @param unit
+     *            Unit of the axis
+     * @param dataType
+     *            Type of the data (as a string)
+     * @param axisDomain
+     *            Optional domain for the axis
+     */
+    @JsonCreator
+    public TmfXYAxisDescriptionStub(
+            @JsonProperty("label") String label,
+            @JsonProperty("unit") String unit,
+            @JsonProperty("dataType") String dataType,
+            @JsonProperty("axisDomain") @Nullable IAxisDomainStub axisDomain) {
+        fLabel = Objects.requireNonNull(label, "The 'label' json field was not set");
+        fUnit = Objects.requireNonNull(unit, "The 'unit' json field was not set");
+        fDataType = Objects.requireNonNull(dataType, "The 'dataType' json field was not set");
+        fAxisDomain = axisDomain;
+    }
+
+    /**
+     * Get the axis label
+     *
+     * @return the label
+     */
+    public String getLabel() {
+        return fLabel;
+    }
+
+    /**
+     * Get the unit of the axis
+     *
+     * @return the unit
+     */
+    public String getUnit() {
+        return fUnit;
+    }
+
+    /**
+     * Get the data type of the axis
+     *
+     * @return the data type
+     */
+    public String getDataType() {
+        return fDataType;
+    }
+
+    /**
+     * Get the axis domain
+     *
+     * @return the axis domain, if any
+     */
+    public @Nullable IAxisDomainStub getAxisDomain() {
+        return fAxisDomain;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/XySeriesStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/XySeriesStub.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2020 École Polytechnique de Montréal
+ * Copyright (c) 2020, 2025 École Polytechnique de Montréal
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -29,9 +29,11 @@ public class XySeriesStub implements Serializable {
 
     private final String fName;
     private final int fId;
-    private final List<Long> fXValues;
+    private final ISamplingStub fSampling;
     private final List<Double> fYValues;
     private final OutputElementStyleStub fStyle;
+    private final TmfXYAxisDescriptionStub fXAxisDescription;
+    private final TmfXYAxisDescriptionStub fYAxisDescription;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -46,18 +48,26 @@ public class XySeriesStub implements Serializable {
      *            The values for the y axis of this series
      * @param style
      *            The style for this series
+     * @param xAxisDescription
+     *            The description for x axis
+     * @param yAxisDescription
+     *            The description for y axis
      */
     @JsonCreator
     public XySeriesStub(@JsonProperty("seriesName") String name,
             @JsonProperty("seriesId") Integer id,
-            @JsonProperty("xValues") List<Long> xValues,
+            @JsonProperty("xValues") ISamplingStub xValues,
             @JsonProperty("yValues") List<Double> yValues,
-            @JsonProperty("style") OutputElementStyleStub style) {
+            @JsonProperty("style") OutputElementStyleStub style,
+            @JsonProperty("xValuesDescription") TmfXYAxisDescriptionStub xAxisDescription,
+            @JsonProperty("yValuesDescription") TmfXYAxisDescriptionStub yAxisDescription) {
         fName = Objects.requireNonNull(name, "The 'seriesName' json field was not set");
         fId = Objects.requireNonNull(id, "The 'seriesId' json field was not set");
-        fXValues = Objects.requireNonNull(xValues, "The 'xValues' json field was not set");
+        fSampling = Objects.requireNonNull(xValues, "The 'xValues' json field was not set");
         fYValues = Objects.requireNonNull(yValues, "The 'yValues' json field was not set");
         fStyle = Objects.requireNonNull(style, "The 'style' json field was not set");
+        fXAxisDescription = xAxisDescription;
+        fYAxisDescription = yAxisDescription;
     }
 
     /**
@@ -83,8 +93,8 @@ public class XySeriesStub implements Serializable {
      *
      * @return The values on the x axis
      */
-    public List<Long> getXValues() {
-        return fXValues;
+    public ISamplingStub getXValues() {
+        return fSampling;
     }
 
     /**
@@ -103,5 +113,23 @@ public class XySeriesStub implements Serializable {
      */
     public OutputElementStyleStub getStyle() {
         return fStyle;
+    }
+
+    /**
+     * Get the description for x axis
+     *
+     * @return The description for x axis
+     */
+    public TmfXYAxisDescriptionStub getXAxisDescription() {
+        return fXAxisDescription;
+    }
+
+    /**
+     * Get the description for y axis
+     *
+     * @return The description for y axis
+     */
+    public TmfXYAxisDescriptionStub getYAxisDescription() {
+        return fYAxisDescription;
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 Ericsson
+ * Copyright (c) 2018, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -119,6 +119,11 @@ public abstract class RestServerTest {
     protected static final String CALL_STACK_DATAPROVIDER_ID = "org.eclipse.tracecompass.internal.analysis.profiling.callstack.provider.CallStackDataProvider";
 
     /**
+     * Callstack function density data provider ID
+     */
+    protected static final String CALL_STACK_FUNCTION_DENSITY_DATAPROVIDER_ID = "org.eclipse.tracecompass.analysis.profiling.core.callstack.functiondensity.provider";
+
+    /**
      * Requested times key
      */
     protected static final String REQUESTED_TIMES_KEY = "requested_times";
@@ -170,6 +175,11 @@ public abstract class RestServerTest {
      * XY series path segment
      */
     public static final String XY_SERIES_PATH = "xy";
+
+    /**
+     * Generic XY path segment
+     */
+    public static final String GENERIC_XY_PATH = "genericXY";
 
     /**
      * States path segment
@@ -599,6 +609,24 @@ public abstract class RestServerTest {
     }
 
     /**
+     * Get the {@link WebTarget} for the generic xy tree endpoint.
+     *
+     * @param expUUID
+     *            Experiment UUID
+     * @param dataProviderId
+     *            Data provider ID
+     * @return The generic xy tree endpoint
+     */
+    public static WebTarget getGenericXYTreeEndpoint(String expUUID, String dataProviderId) {
+        return getApplicationEndpoint().path(EXPERIMENTS)
+                .path(expUUID)
+                .path(OUTPUTS_PATH)
+                .path(GENERIC_XY_PATH)
+                .path(dataProviderId)
+                .path(TREE_PATH);
+    }
+
+    /**
      * Get the {@link WebTarget} for the XY series endpoint.
      *
      * @param expUUID     *            Experiment UUID
@@ -611,6 +639,25 @@ public abstract class RestServerTest {
                 .path(expUUID)
                 .path(OUTPUTS_PATH)
                 .path(XY_PATH)
+                .path(dataProviderId)
+                .path(XY_SERIES_PATH);
+    }
+
+    /**
+     * Get the {@link WebTarget} for the generic XY series end point with
+     * non-time x-axis.
+     *
+     * @param expUUID
+     *            Experiment UUID
+     * @param dataProviderId
+     *            Data provider ID
+     * @return The generic XY series endpoint
+     */
+    public static WebTarget getGenericXYSeriesEndpoint(String expUUID, String dataProviderId) {
+        return getApplicationEndpoint().path(EXPERIMENTS)
+                .path(expUUID)
+                .path(OUTPUTS_PATH)
+                .path(GENERIC_XY_PATH)
                 .path(dataProviderId)
                 .path(XY_SERIES_PATH);
     }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/webapp/SamplingSerializerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/webapp/SamplingSerializerTest.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.webapp;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp.SamplingSerializer;
+import org.eclipse.tracecompass.tmf.core.model.ISampling;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Categories;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Range;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Ranges;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Timestamps;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Test suite for {@link SamplingSerializer} and {@link SamplingDeserializer}.
+ * <p>
+ * Validates JSON round-trip behavior for different {@link ISampling}
+ * subtypes: {@link Timestamps}, {@link Categories}, and {@link Ranges}.
+ *
+ * @author Siwei Zhang
+ */
+public class SamplingSerializerTest {
+
+    private ObjectMapper fMapper;
+
+    /**
+     * Set up the {@link ObjectMapper} and register the custom serializer and
+     * deserializer for {@link ISampling}.
+     */
+    @Before
+    public void setup() {
+        fMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(ISampling.class, new SamplingSerializer());
+        fMapper.registerModule(module);
+    }
+
+    /**
+     * Test round-trip serialization and deserialization for
+     * {@link ISampling.Timestamps}. The format is a flat array of @NonNull Longs.
+     *
+     * @throws JsonProcessingException
+     *             if JSON processing fails
+     */
+    @Test
+    public void testTimestampsRoundTrip() throws JsonProcessingException {
+        ISampling original = new Timestamps(new long[] { 1, 2, 3 });
+        String json = fMapper.writeValueAsString(original);
+        assertEquals("[1,2,3]", json);
+    }
+
+    /**
+     * Test round-trip serialization and deserialization for
+     * {@link ISampling.Categories}. The format is an array of strings.
+     *
+     * @throws JsonProcessingException
+     *             if JSON processing fails
+     */
+    @Test
+    public void testCategoriesRoundTrip() throws JsonProcessingException {
+        ISampling original = new Categories(List.of("Read", "Write", "Idle"));
+        String json = fMapper.writeValueAsString(original);
+        assertEquals("[\"Read\",\"Write\",\"Idle\"]", json);
+    }
+
+    /**
+     * Test round-trip serialization and deserialization for
+     * {@link ISampling.Ranges}. The format is a 2D array of timestamp
+     * ranges, i.e., {@code [[start, end], ...]}.
+     *
+     * @throws JsonProcessingException
+     *             if JSON processing fails
+     */
+    @Test
+    public void testTimeRangesRoundTrip() throws JsonProcessingException {
+        ISampling original = new Ranges(List.of(
+                new Range<>(1L, 2L),
+                new Range<>(2L, 3L),
+                new Range<>(3L, 4L)
+        ));
+        String json = fMapper.writeValueAsString(original);
+        assertEquals("[[1,2],[2,3],[3,4]]", json);
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomain.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomain.java
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Represents the domain of values for a chart axis.
+ * <p>
+ * The domain can either be categorical (e.g., discrete string labels) or a
+ * numeric range (e.g., time or duration values).
+ * <p>
+ * This interface is used for OpenAPI schema generation and supports polymorphic
+ * serialization via {@code type} discriminator.
+ */
+@Schema(description = "Domain of values supported on a chart axis. Can be either categorical or numeric range.")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = AxisDomainCategorical.class, name = "categorical"),
+    @JsonSubTypes.Type(value = AxisDomainTimeRange.class, name = "timeRange")
+})
+public interface AxisDomain {
+
+    /**
+     * Returns the type of axis domain.
+     * <p>
+     * This is used as a discriminator to identify the specific subtype
+     * implementation (e.g., "categorical", "timeRange").
+     *
+     * @return A string identifying the domain type
+     */
+    @Schema(description = "Type of axis domain (e.g., 'categorical' or 'timeRange')", requiredMode = RequiredMode.REQUIRED)
+    @JsonProperty("type")
+    String getType();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomainCategorical.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomainCategorical.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Represents a categorical domain of values for an axis, where values are
+ * predefined strings such as labels or states (e.g., "read", "write", "idle").
+ * <p>
+ * Used in Swagger schema generation for chart axis descriptions.
+ */
+public class AxisDomainCategorical implements AxisDomain {
+
+    private final @NonNull Set<String> categories;
+
+    /**
+     * Constructor
+     *
+     * @param categories
+     *            The set of category labels
+     */
+    @JsonCreator
+    public AxisDomainCategorical(
+            @JsonProperty("categories")
+            @NonNull Set<String> categories) {
+        this.categories = categories;
+    }
+
+    @Override
+    @Schema(description = "Type of axis domain", requiredMode = RequiredMode.REQUIRED)
+    public String getType() {
+        return "categorical";
+    }
+
+    /**
+     * @return The set of category names
+     */
+    @ArraySchema(arraySchema = @Schema(description = "List of category labels on the axis"), schema = @Schema(requiredMode = RequiredMode.REQUIRED))
+    public @NonNull Set<String> getCategories() {
+        return categories;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomainTimeRange.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/AxisDomainTimeRange.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Represents a range-based domain of values for an axis, typically numeric
+ * (e.g., execution durations, time intervals).
+ * <p>
+ * Used in Swagger schema generation for chart axis descriptions.
+ */
+public class AxisDomainTimeRange implements AxisDomain {
+
+    private final long start;
+    private final long end;
+
+    /**
+     * Constructor
+     *
+     * @param start
+     *            The minimum value of the axis domain
+     * @param end
+     *            The maximum value of the axis domain
+     */
+    @JsonCreator
+    public AxisDomainTimeRange(
+            @JsonProperty("start") long start,
+            @JsonProperty("end") long end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    @Schema(description = "Type of axis domain", requiredMode = RequiredMode.REQUIRED)
+    public String getType() {
+        return "timeRange";
+    }
+
+    /**
+     * @return The start of the domain range
+     */
+    @Schema(description = "Start of the axis range", requiredMode = RequiredMode.REQUIRED)
+    public long getStart() {
+        return start;
+    }
+
+    /**
+     * @return The end of the domain range
+     */
+    @Schema(description = "End of the axis range", requiredMode = RequiredMode.REQUIRED)
+    public long getEnd() {
+        return end;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/GenericTimeRange.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/GenericTimeRange.java
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ *
+ * This time range can optionally include a number of sampling points. The
+ * sampling values are not restricted to timestamps—they can represent other
+ * types of samples.
+ */
+@Schema(description = "A generic time range with optional sampling count. Sampling points may represent values other than timestamps.")
+public interface GenericTimeRange {
+
+    /**
+     * @return The inclusive start of the range.
+     */
+    @Schema(description = "Start of the range", requiredMode = RequiredMode.REQUIRED)
+    long getStart();
+
+    /**
+     * @return The inclusive end of the range.
+     */
+    @Schema(description = "End of the range", requiredMode = RequiredMode.REQUIRED)
+    long getEnd();
+
+    /**
+     * @return The number of samples to compute within the range.
+     */
+    @Schema(description = "Optional number of samples (1–65536) to generate within the range", requiredMode = RequiredMode.NOT_REQUIRED)
+    int getNbSamples();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/GenericXYQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/GenericXYQueryParameters.java
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ *
+ * Uses generic time range for requested time range, which allows sampling
+ * values are not restricted to timestamps.
+ */
+public interface GenericXYQueryParameters {
+
+    /**
+     * @return The parameters.
+     */
+    @NonNull
+    @Schema(requiredMode = RequiredMode.REQUIRED)
+    GenericXYRequestedParameters getParameters();
+
+    /**
+     * Property names below use underscores as per trace-server protocol.
+     */
+    interface GenericXYRequestedParameters {
+
+        @JsonProperty("requested_timerange")
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        GenericTimeRange getRequestedTimeRange();
+
+        @JsonProperty("requested_items")
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int[] getRequestedItems();
+
+        @JsonProperty("filter_query_parameters")
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED)
+        RequestedFilterQueryParameters getFilterQueryParameters();
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Sampling.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Sampling.java
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+import java.util.List;
+
+/**
+ * Describes alternative representations of sampling options.
+ * Used for OpenAPI generation.
+ */
+@Schema(oneOf = {
+        Sampling.TimestampSampling.class,
+        Sampling.CategorySampling.class,
+        Sampling.RangeSampling.class
+})
+public interface Sampling {
+
+    /**
+     * Sampling as list of timestamps.
+     */
+    public static class TimestampSampling {
+        /**
+         * The sampling points as timestamp values.
+         */
+        @Schema(
+            description = "Sampling as list of timestamps",
+            requiredMode = RequiredMode.REQUIRED
+        )
+        public long[] sampling;
+    }
+
+    /**
+     * Sampling as list of categories.
+     */
+    public static class CategorySampling {
+        /**
+         * The sampling points as category names or labels.
+         */
+        @Schema(
+            description = "Sampling as list of categories",
+            requiredMode = RequiredMode.REQUIRED
+        )
+        public String[] sampling;
+    }
+
+    /**
+     * Sampling as a list of [start, end] ranges.
+     */
+    public static class RangeSampling {
+        /**
+         * The list of sampling ranges, each with a start and end value.
+         */
+        @Schema(
+            description = "Sampling as list of [start, end] timestamp ranges",
+            requiredMode = RequiredMode.REQUIRED
+        )
+        public List<StartEndRange> sampling;
+    }
+
+    /**
+     * Represents a closed interval [start, end] for a sampling range.
+     */
+    public static class StartEndRange {
+        /**
+         * Start timestamp of the range (inclusive).
+         */
+        @Schema(description = "Start timestamp of the range", requiredMode = RequiredMode.REQUIRED)
+        public long start;
+
+        /**
+         * End timestamp of the range (inclusive).
+         */
+        @Schema(description = "End timestamp of the range", requiredMode = RequiredMode.REQUIRED)
+        public long end;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/SeriesModel.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/SeriesModel.java
@@ -42,8 +42,12 @@ public interface SeriesModel {
      * @return The X values.
      */
     @JsonProperty("xValues")
-    @ArraySchema(arraySchema = @Schema(description = "Series' X values"), schema = @Schema(requiredMode = RequiredMode.REQUIRED))
-    long[] getXValues();
+    @Schema(description = "Sampling values", requiredMode = RequiredMode.REQUIRED, oneOf = {
+            Sampling.TimestampSampling.class,
+            Sampling.CategorySampling.class,
+            Sampling.RangeSampling.class
+    })
+    Sampling getXValues();
 
     /**
      * @return The Y values.
@@ -51,6 +55,20 @@ public interface SeriesModel {
     @JsonProperty("yValues")
     @ArraySchema(arraySchema = @Schema(description = "Series' Y values"), schema = @Schema(requiredMode = RequiredMode.REQUIRED))
     double[] getYValues();
+
+    /**
+     * @return The X values' description.
+     */
+    @JsonProperty("xValuesDescription")
+    @ArraySchema(arraySchema = @Schema(description = "Series' X axis description"), schema = @Schema(requiredMode = RequiredMode.REQUIRED))
+    XYAxisDescription getXAxisDescription();
+
+    /**
+     * @return The Y values' description.
+     */
+    @JsonProperty("yValuesDescription")
+    @ArraySchema(arraySchema = @Schema(description = "Series' Y axis description"), schema = @Schema(requiredMode = RequiredMode.REQUIRED))
+    XYAxisDescription getYAxisDescription();
 
     /**
      * @return The series style.

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/XYAxisDescription.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/XYAxisDescription.java
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ * Represents an axis description for XY charts.
+ */
+@Schema(description = "Describes a single axis in an XY chart, including label, unit, data type, and optional domain.")
+public interface XYAxisDescription {
+
+    /**
+     * @return Axis label, e.g., "Time", "Duration", etc.
+     */
+    @NonNull
+    @Schema(description = "Label for the axis", requiredMode = RequiredMode.REQUIRED)
+    String getLabel();
+
+    /**
+     * @return Unit string, such as "ns", "ms", or "" (empty if not applicable).
+     */
+    @NonNull
+    @Schema(description = "Unit associated with this axis (e.g., ns, ms)", requiredMode = RequiredMode.REQUIRED)
+    String getUnit();
+
+    /**
+     * @return The data type of the axis values.
+     */
+    @NonNull
+    @Schema(description = "The type of data this axis represents", requiredMode = RequiredMode.REQUIRED)
+    DataType getDataType();
+
+    /**
+     * @return Optional domain of values that this axis can take.
+     */
+    @JsonProperty("axisDomain")
+    @Schema(description = "Optional domain of values that this axis supports", requiredMode = RequiredMode.NOT_REQUIRED)
+    @Nullable AxisDomain getAxisDomain();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Ericsson
+ * Copyright (c) 2021, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -97,6 +97,7 @@ public final class EndpointConstants {
     static final String DIA = "Diagnostic"; //$NON-NLS-1$
     static final String DT = "Data Tree"; //$NON-NLS-1$
     static final String EXP = "Experiments"; //$NON-NLS-1$
+    static final String GXY = "Generic XY"; //$NON-NLS-1$
     static final String IDF = "Identifier"; //$NON-NLS-1$
     static final String OCG = "Output Configurations"; //$NON-NLS-1$
     static final String STY = "Styles"; //$NON-NLS-1$
@@ -170,6 +171,7 @@ public final class EndpointConstants {
     static final String MARKER_CATEGORIES_EX = "\"" + REQUESTED_MARKER_CATEGORIES_KEY + "\": [\"category1\", \"category2\"]"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String MARKER_SET_EX = "\"" + REQUESTED_MARKER_SET_KEY + "\": \"markerSetId\","; //$NON-NLS-1$ //$NON-NLS-2$
     static final String TIMERANGE_EX = "\"" + REQUESTED_TIMERANGE_KEY + "\": {\"start\": 111111111, \"end\": 222222222, \"nbTimes\": 1920}"; //$NON-NLS-1$ //$NON-NLS-2$
+    static final String TIMERANGE_SAMPLING_EX = "\"" + REQUESTED_TIMERANGE_KEY + "\": {\"start\": 111111111, \"end\": 222222222, \"nbSamples\": 1920}"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String FILTER_QUERY_PARAMETERS_EX = "\"" + FILTER_QUERY_PARAMETERS_KEY + "\": {\"" + FILTER_QUERY_STRATEGY + "\": \"SAMPLED\", \"" + FILTER_EXPRESSIONS_MAP + "\": {\"1\":[\"openat\", \"duration>10ms\"]}}"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
     static final String TIMERANGE_EX_TREE = "\"" + REQUESTED_TIMERANGE_KEY + "\": {\"start\": 111111111, \"end\": 222222222}"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String TIMES_EX_TT = "\"" + REQUESTED_TIME_KEY + "\": [111200000],"; //$NON-NLS-1$ //$NON-NLS-2$

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/AxisDomainSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/AxisDomainSerializer.java
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp;
+
+import java.io.IOException;
+
+import org.eclipse.tracecompass.tmf.core.model.IAxisDomain;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Custom Jackson serializer for {@link IAxisDomain}.
+ * <p>
+ * This serializer outputs a JSON representation including the {@code "type"}
+ * discriminator and the appropriate fields depending on the concrete subtype.
+ * </p>
+ *
+ * Example JSON output:
+ * <pre>
+ * {
+ *   "type": "categorical",
+ *   "categories": ["foo", "bar"]
+ * }
+ *
+ * {
+ *   "type": "timeRange",
+ *   "start": 0,
+ *   "end": 100
+ * }
+ * </pre>
+ *
+ * @author Siwei Zhang
+ * @since 10.2
+ */
+public class AxisDomainSerializer extends JsonSerializer<IAxisDomain> {
+
+    private static final String TYPE = "type"; //$NON-NLS-1$
+
+    @Override
+    public void serialize(IAxisDomain value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+
+        if (value instanceof IAxisDomain.Categorical categorical) {
+            gen.writeStringField(TYPE, "categorical"); //$NON-NLS-1$
+            gen.writeObjectField("categories", categorical.categories()); //$NON-NLS-1$
+        } else if (value instanceof IAxisDomain.Range timeRange) {
+            gen.writeStringField(TYPE, "timeRange"); //$NON-NLS-1$
+            gen.writeNumberField("start", timeRange.start()); //$NON-NLS-1$
+            gen.writeNumberField("end", timeRange.end()); //$NON-NLS-1$
+        } else {
+            throw new IllegalArgumentException("Unsupported AxisDomain implementation: " + value.getClass()); //$NON-NLS-1$
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/JacksonObjectMapperProvider.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/JacksonObjectMapperProvider.java
@@ -24,7 +24,9 @@ import org.eclipse.tracecompass.tmf.core.config.ITmfConfigParamDescriptor;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfiguration;
 import org.eclipse.tracecompass.tmf.core.config.ITmfConfigurationSourceType;
 import org.eclipse.tracecompass.tmf.core.model.DataProviderDescriptor;
+import org.eclipse.tracecompass.tmf.core.model.IAxisDomain;
 import org.eclipse.tracecompass.tmf.core.model.OutputElementStyle;
+import org.eclipse.tracecompass.tmf.core.model.ISampling;
 import org.eclipse.tracecompass.tmf.core.model.annotations.Annotation;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.ITimeGraphArrow;
 import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphEntryModel;
@@ -62,6 +64,7 @@ public class JacksonObjectMapperProvider implements ContextResolver<ObjectMapper
             module.addSerializer(DataProviderDescriptor.class, new DataProviderDescriptorSerializer());
             module.addSerializer(ITmfXyModel.class, new XYModelSerializer());
             module.addSerializer(ISeriesModel.class, new SeriesModelSerializer());
+            module.addSerializer(ISampling.class, new SamplingSerializer());
             module.addSerializer(TimeGraphState.class, new TimeGraphStateSerializer());
             module.addSerializer(ITimeGraphArrow.class, new TimeGraphArrowSerializer());
             module.addSerializer(TimeGraphRowModel.class, new TimeGraphRowModelSerializer());
@@ -76,6 +79,7 @@ public class JacksonObjectMapperProvider implements ContextResolver<ObjectMapper
             module.addSerializer(ITmfConfiguration.class, new TmfConfigurationSerializer());
             module.addSerializer(ITmfConfigurationSourceType.class, new TmfConfigurationSourceTypeSerializer());
             module.addSerializer(ITmfConfigParamDescriptor.class, new TmfConfigParamDescriptorSerializer());
+            module.addSerializer(IAxisDomain.class, new AxisDomainSerializer());
 
             // create JsonProvider to provide custom ObjectMapper
             JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/SamplingSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/SamplingSerializer.java
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.tmf.core.model.ISampling;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Categories;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Range;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Ranges;
+import org.eclipse.tracecompass.tmf.core.model.ISampling.Timestamps;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Custom serializer for all Sampling subtypes.
+ * - Timestamps → flat array: [1, 2, 3]
+ * - Categories → array of strings: ["Read", "Write"]
+ * - TimeRanges → array of arrays: [[1, 2], [2, 3]]
+ */
+public class SamplingSerializer extends StdSerializer<ISampling> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor
+     */
+    public SamplingSerializer() {
+        super(ISampling.class);
+    }
+
+    @Override
+    public void serialize(ISampling value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (value instanceof Timestamps timestamps) {
+            gen.writeArray(timestamps.timestamps(), 0, timestamps.timestamps().length);
+
+        } else if (value instanceof Categories categories) {
+            gen.writeStartArray();
+            for (String category : categories.categories()) {
+                gen.writeString(category);
+            }
+            gen.writeEndArray();
+
+        } else if (value instanceof Ranges timeRanges) {
+            gen.writeStartArray();
+            for (Range<@NonNull Long> range : timeRanges.ranges()) {
+                gen.writeStartArray();
+                gen.writeNumber(range.start());
+                gen.writeNumber(range.end());
+                gen.writeEndArray();
+            }
+            gen.writeEndArray();
+        } else {
+            throw new IllegalArgumentException("Unknown Sampling type: " + value.getClass().getName()); //$NON-NLS-1$
+        }
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/SeriesModelSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/SeriesModelSerializer.java
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019 Ericsson
+ * Copyright (c) 2019, 2025 Ericsson
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License 2.0 which
@@ -47,13 +47,15 @@ public class SeriesModelSerializer extends StdSerializer<@NonNull ISeriesModel> 
         gen.writeStartObject();
         gen.writeNumberField("seriesId", value.getId()); //$NON-NLS-1$
         gen.writeStringField("seriesName", value.getName()); //$NON-NLS-1$
-        gen.writeObjectField("xValues", value.getXAxis()); //$NON-NLS-1$
+        gen.writeObjectField("xValues", value.getSampling()); //$NON-NLS-1$
         gen.writeObjectField("yValues", value.getData()); //$NON-NLS-1$
 
         // no-op trim below, null-related (unlikely case) warning otherwise-
         String type = value.getDisplayType().name().toLowerCase().trim();
         OutputElementStyle style = new OutputElementStyle(null, ImmutableMap.of(StyleProperties.SERIES_TYPE, type));
         gen.writeObjectField("style", style); //$NON-NLS-1$
+        gen.writeObjectField("xValuesDescription", value.getXAxisDescription()); //$NON-NLS-1$
+        gen.writeObjectField("yValuesDescription", value.getYAxisDescription()); //$NON-NLS-1$
         gen.writeEndObject();
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
@@ -134,8 +134,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.antlr.runtime"/>
       <plugin id="org.aopalliance"/>
       <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
-      <plugin id="org.apache.commons.commons-logging"/>
       <plugin id="org.apache.commons.commons-io"/>
+      <plugin id="org.apache.commons.commons-logging"/>
       <plugin id="org.apache.commons.lang3"/>
       <plugin id="org.apache.felix.gogo.command"/>
       <plugin id="org.apache.felix.gogo.runtime"/>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

This series of commits add the new `/BarChart` endpoint proposed in:

https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/114

It requires the introduced bar chart data provider implemented in:

https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/291

`CallStackAnalysis` is used as the initial example input to demonstrate this functionality through a function density view.

### How to test

You can test the new bar chart data provider endpoints using the following sequence of HTTP requests.

#### Open trace

```
POST http://localhost:8080/tsp/api/traces
Content-Type: application/json

{
  "parameters": {
    "uri": "/path/to/lttng/ust/trace",
    "name": "ls_ust"
  }
}
```
#### Create an experiment

```
POST http://localhost:8080/tsp/api/experiments
Content-Type: application/json

{
  "parameters": {
    "name": "testing_ust",
    "traces": ["2b8477ca-25d9-3ed4-83db-6736a7a33d46"]
  }
}
```

#### (optional) Check bar chart provider availability

```
GET http://localhost:8080/tsp/api/experiments/613c18b7-d239-3377-9482-2136946d4749/outputs/org.eclipse.tracecompass.analysis.profiling.core.callstack.barchart.provider
```

#### Get tree and axis descriptions

```
POST http://localhost:8080/tsp/api/experiments/613c18b7-d239-3377-9482-2136946d4749/outputs/genericXY/org.eclipse.tracecompass.analysis.profiling.core.callstack.functiondensity.provider/tree
Content-Type: application/json

{
  "parameters": {
    "requested_timerange": {
      "start": 111111111,
      "end": 222222222
    }
  }
}
```

#### Get bar chart data

```
POST http://localhost:8080/tsp/api/experiments/613c18b7-d239-3377-9482-2136946d4749/outputs/genericXY/org.eclipse.tracecompass.analysis.profiling.core.callstack.functiondensity.provider/xy
Content-Type: application/json

{
  "parameters": {
    "requested_items": [1, 2, 3, 4],
    "requested_timerange": {
      "start": 1750773997065742471,
      "end": 1750774010897424378,
      "nbSamples": 5
    }
  }
}
```

### Follow-ups

 - Additional changes will be submitted to tsp-client and vscode-trace-extension to support bar chart views end-to-end.

### Review checklist

- [Y] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
