### PR TITLE
ros2: store instrumentation version per-process, not per-trace

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/messages/Ros2MessagesStateProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/analysis/messages/Ros2MessagesStateProvider.java
@@ -66,7 +66,7 @@ public class Ros2MessagesStateProvider extends AbstractRos2StateProvider {
 
     private static final int VERSION_NUMBER = 0;
 
-    private final ITmfStateSystem fObjectsSs;
+    private final @NonNull ITmfStateSystem fObjectsSs;
     private boolean fInitialSetupDone = false;
 
     // Publications
@@ -102,7 +102,7 @@ public class Ros2MessagesStateProvider extends AbstractRos2StateProvider {
      */
     public Ros2MessagesStateProvider(ITmfTrace trace, ITmfStateSystem objectsSs) {
         super(trace, Ros2MessagesAnalysis.getFullAnalysisId());
-        fObjectsSs = objectsSs;
+        fObjectsSs = Objects.requireNonNull(objectsSs);
     }
 
     @Override
@@ -131,7 +131,7 @@ public class Ros2MessagesStateProvider extends AbstractRos2StateProvider {
 
         eventHandleHelpers(event);
         // If we can get the source_timestamp from rmw, don't process DDS events
-        if (!isPubSourceTimestampAvailableFromRmw()) {
+        if (!isPubSourceTimestampAvailableFromRmw(event, fObjectsSs)) {
             eventHandlePublishDds(event, ss, timestamp);
         }
         eventHandlePublish(event, ss, timestamp);
@@ -154,7 +154,7 @@ public class Ros2MessagesStateProvider extends AbstractRos2StateProvider {
          * known/"valid" DDS writers and rmw publishers and only consider events
          * concerning those DDS writers or rmw publishers.
          */
-        if (!isPubSourceTimestampAvailableFromRmw()) {
+        if (!isPubSourceTimestampAvailableFromRmw(event, fObjectsSs)) {
             // dds:create_writer
             if (isEvent(event, LAYOUT.eventDdsCreateWriter())) {
                 /**
@@ -238,7 +238,7 @@ public class Ros2MessagesStateProvider extends AbstractRos2StateProvider {
         }
         // rmw_publish
         // We only need these events if we can get the source_timestamp
-        else if (isPubSourceTimestampAvailableFromRmw() && isEvent(event, LAYOUT.eventRmwPublish())) {
+        else if (isPubSourceTimestampAvailableFromRmw(event, fObjectsSs) && isEvent(event, LAYOUT.eventRmwPublish())) {
             handleRmwPublish(event, ss, timestamp);
         }
     }

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/HostProcess.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/HostProcess.java
@@ -28,6 +28,7 @@ public class HostProcess implements Comparable<HostProcess> {
 
     private static Comparator<HostProcess> COMPARATOR = Comparator.comparing(HostProcess::getHostId)
             .thenComparing(HostProcess::getPid);
+    private static final @NonNull String STRING_ID_SEP = "|"; //$NON-NLS-1$
 
     private final @NonNull HostInfo fHostId;
     private final @NonNull Long fPid;
@@ -88,6 +89,15 @@ public class HostProcess implements Comparable<HostProcess> {
         }
         HostProcess o = (HostProcess) obj;
         return o.fHostId.equals(fHostId) && o.fPid.equals(fPid);
+    }
+
+    /**
+     * @return the string ID to uniquely represent this process
+     */
+    public @NonNull String getStringId() {
+        return String.format(
+                "%d%s%s", //$NON-NLS-1$
+                getPid(), STRING_ID_SEP, getHostId().getId());
     }
 
     @Override

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/HostProcessValue.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/model/HostProcessValue.java
@@ -116,8 +116,8 @@ public abstract class HostProcessValue<@NonNull T extends Comparable<T>> extends
      */
     public @NonNull String getStringId() {
         return String.format(
-                "%s%s%d%s%s", //$NON-NLS-1$
-                valueToString(), STRING_ID_SEP, getPid(), STRING_ID_SEP, getHostProcess().getHostId().getId());
+                "%s%s%s", //$NON-NLS-1$
+                valueToString(), STRING_ID_SEP, getHostProcess().getStringId());
     }
 
     @Override

--- a/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/IRos2EventLayout.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.ros2.core/src/org/eclipse/tracecompass/incubator/internal/ros2/core/trace/layout/IRos2EventLayout.java
@@ -36,6 +36,11 @@ public interface IRos2EventLayout {
 
     public static String PROVIDER_NAME = "ros2:"; //$NON-NLS-1$
     public static String DDS_PROVIDER_NAME = "dds:"; //$NON-NLS-1$
+    /**
+     * Last version before the 'version' field was added. As it turns out, the
+     * field was added in 0.1.0.
+     */
+    public static final String TRACETOOLS_VERSION_UNKNOWN = "0.0.0"; //$NON-NLS-1$
 
     /**
      * The default layout


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

ROS 2 traces include the version of the ROS package used to generate the trace, which effectively gives us a version number for the instrumentation. This helps us interpret the trace events and their fields.

We are reading this version number from ROS 2 traces and are currently storing it at the trace level. However, this version number does not really belong to the trace: it belongs to the process itself.

This flaw became evident when trying to combine 2 traces of the same ROS 2 system/processes:

1. Trace that includes trace events from the start of the application, which includes the version information
2. Trace that includes trace events from later in the application's lifetime, which does not include the version information
    * This is because the version information is currently collected through a tracepoint triggered during the initialization of ROS 2

Therefore, we need to associate the version information to the process. In the case presented above, since the processes being traced by both traces are the same, the same version information will be shared.

Do this by storing the version number in the Ros2Objects state system as a `{ process -> version number }` map.

![image](https://github.com/user-attachments/assets/0ef817bf-0432-44d0-9674-5e57f3e3a38b)

This is part of https://github.com/ros2/ros2_tracing/issues/44.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the 2 traces in this archive as an experiment: [2_sessions.zip](https://github.com/user-attachments/files/21151295/2_sessions.zip)
2. Check that the version numbers get properly parsed and written to the state system (see screenshot above)

(There are analysis errors due to unrelated missing events in the trace.)

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
