### PR TITLE
server: Introduce ErrorResponse and use it in error responses

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderConfigurationServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/DataProviderConfigurationServiceTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.DataProviderService;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.ErrorResponseImpl;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.DataProviderDescriptorStub;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.ExperimentModelStub;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.TestDataProviderFactory;
@@ -93,14 +94,14 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = configTypesEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         WebTarget singleTypeEndpoint = configTypesEndpoint.path(TestSchemaConfigurationSource.TYPE.getId());
         try (Response response = singleTypeEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Unknown data provider
@@ -108,14 +109,14 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = configTypesEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         singleTypeEndpoint = configTypesEndpoint.path(TestSchemaConfigurationSource.TYPE.getId());
         try (Response response = singleTypeEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Test config type is not applicable for another data provider
@@ -124,7 +125,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = singleTypeEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         configTypesEndpoint = getConfigEndpoint(exp.getUUID().toString(), TestDataProviderFactory.ID);
@@ -132,7 +133,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = singleTypeEndpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_CONFIGURATION_TYPE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_CONFIGURATION_TYPE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
     }
 
@@ -194,21 +195,21 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         // Unknown experiment
         try (Response response = assertDpPostWithErrors(dpCreationEndpoint, configuration)) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Unknown data provider
         dpCreationEndpoint = getDpCreationEndpoint(exp.getUUID().toString(), UNKNOWN_DP_ID);
         try (Response response = assertDpPostWithErrors(dpCreationEndpoint, configuration)) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Test config type is not applicable for another data provider
         dpCreationEndpoint = getDpCreationEndpoint(exp.getUUID().toString(), CALL_STACK_DATAPROVIDER_ID);
         try (Response response = assertDpPostWithErrors(dpCreationEndpoint, configuration)) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Invalid config type ID
@@ -222,7 +223,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         configuration = builder.build();
         try (Response response = assertDpPostWithErrors(dpCreationEndpoint, configuration)) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_CONFIGURATION_TYPE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_CONFIGURATION_TYPE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
     }
 
@@ -244,7 +245,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = dpDeletionEndpoint.request().delete()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Unknown input data provider
@@ -253,7 +254,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = dpDeletionEndpoint.request().delete()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Unknown derived data provider
@@ -262,7 +263,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = dpDeletionEndpoint.request().delete()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_DERIVED_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_DERIVED_PROVIDER + ": " + UNKNOWN_DP_ID, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         Map<String, Object> params = readParametersFromJson(VALID_JSON_FILENAME);
@@ -283,7 +284,7 @@ public class DataProviderConfigurationServiceTest extends RestServerTest {
         try (Response response = dpDeletionEndpoint.request().delete()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Successful deletion

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TimeGraphDataProviderServiceTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/services/TimeGraphDataProviderServiceTest.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.QueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.DataProviderService;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.ErrorResponseImpl;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.AnnotationCategoriesOutputResponseStub;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.AnnotationModelStub;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.AnnotationResponseStub;
@@ -283,7 +284,7 @@ public class TimeGraphDataProviderServiceTest extends RestServerTest {
         try (Response response = endpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Unknown data provider
@@ -291,7 +292,7 @@ public class TimeGraphDataProviderServiceTest extends RestServerTest {
         try (Response response = endpoint.request(MediaType.APPLICATION_JSON).get()) {
             assertNotNull(response);
             assertEquals(Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
     }
 

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ExperimentErrorResponseStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ExperimentErrorResponseStub.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response class
+ *
+ * @author Bernd Hufmann
+ */
+public class ExperimentErrorResponseStub implements Serializable {
+
+    private static final long serialVersionUID = -5823094821729001182L;
+
+    private final String fTitle;
+    private final String fDetail;
+    private final ExperimentModelStub fExperiment;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param title
+     *            The error title
+     * @param detail
+     *            The error detail
+     * @param experiment
+     *            The experiment
+     */
+    @JsonCreator
+    public ExperimentErrorResponseStub(
+            @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail,
+            @JsonProperty("experiment") ExperimentModelStub experiment) {
+        fTitle = title;
+        fDetail = detail;
+        fExperiment = experiment;
+    }
+
+    /**
+     * Get the error title
+     *
+     * @return the error title
+     */
+    public String getTitle() {
+        return fTitle;
+    }
+
+    /**
+     * Get the error detail
+     *
+     * @return the error detail
+     */
+    public String getDetail() {
+        return fDetail;
+    }
+
+    /**
+     * Get the experiment
+     *
+     * @return the experiment
+     */
+    public ExperimentModelStub getExperiment() {
+        return fExperiment;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TraceErrorResponseStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TraceErrorResponseStub.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response class
+ *
+ * @author Bernd Hufmann
+ */
+public class TraceErrorResponseStub implements Serializable {
+
+    private static final long serialVersionUID = -5823094821729001182L;
+
+    private final String fTitle;
+    private final String fDetail;
+    private final TraceModelStub fTrace;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param title
+     *            The error title
+     * @param detail
+     *            The error detail
+     * @param trace
+     *            The Trace
+     */
+    @JsonCreator
+    public TraceErrorResponseStub(
+            @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail,
+            @JsonProperty("trace") TraceModelStub trace) {
+        fTitle = title;
+        fDetail = detail;
+        fTrace = trace;
+    }
+
+    /**
+     * Get the error title
+     *
+     * @return the error title
+     */
+    public String getTitle() {
+        return fTitle;
+    }
+
+    /**
+     * Get the error detail
+     *
+     * @return the error detail
+     */
+    public String getDetail() {
+        return fDetail;
+    }
+
+    /**
+     * Get the trace
+     *
+     * @return the trace
+     */
+    public TraceModelStub getTrace() {
+        return fTrace;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -45,6 +45,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.OutputConfigurationQueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.views.QueryParameters;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.EndpointConstants;
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services.ErrorResponseImpl;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp.TraceServerConfiguration;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp.WebApplication;
 import org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs.DataProviderDescriptorStub;
@@ -223,6 +224,11 @@ public abstract class RestServerTest {
      * <b>path</b> constant
      */
     public static final String URI = "uri";
+
+    /**
+     * <b>typeID</b> constant
+     */
+    public static final String TYPE_ID = "typeID";
 
     /**
      * Configuration service root path
@@ -909,7 +915,7 @@ public abstract class RestServerTest {
         try (Response response = endpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
             assertNotNull(response);
             assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_SUCH_TRACE, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
 
         // Missing parameters
@@ -933,7 +939,7 @@ public abstract class RestServerTest {
         try (Response response = endpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
             assertNotNull(response);
             assertEquals(Status.METHOD_NOT_ALLOWED.getStatusCode(), response.getStatus());
-            assertEquals(EndpointConstants.NO_PROVIDER, response.readEntity(String.class));
+            assertEquals(EndpointConstants.NO_PROVIDER, response.readEntity(ErrorResponseImpl.class).getTitle());
         }
     }
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ErrorResponse.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ErrorResponse.java
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(description = "Error response that includes an detailed description of the error occured")
+public interface ErrorResponse {
+
+    /**
+     * @return The short, human-readable description of the error.
+     */
+    @Schema(requiredMode = RequiredMode.REQUIRED, description = "The short, human-readable description of the error")
+    String getTitle();
+
+    /**
+     * @return The optional human-readable explanation of the error with details helping the client to correct the error.
+     */
+    @Nullable
+    @Schema(description = "The optional human-readable explanation of the error with details helping the client to correct the error")
+    String getDetail();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Experiment.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Experiment.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * Contributes to the model used for TSP swagger-core annotations.
  */
+@Schema(description = "Experiment model")
 public interface Experiment {
 
     /**

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ExperimentErrorResponse.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ExperimentErrorResponse.java
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(allOf = ErrorResponse.class)
+public interface ExperimentErrorResponse {
+
+    /**
+     * @return the experiment that this error corresponds to
+     */
+    @Schema(requiredMode = RequiredMode.REQUIRED, description = "The experiment that this error corresponds to")
+    Experiment getExperiment();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Trace.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Trace.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 /**
  * Contributes to the model used for TSP swagger-core annotations.
  */
+@Schema(description = "Trace model")
 public interface Trace {
 
     /**

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TraceErrorResponse.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/TraceErrorResponse.java
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(allOf = ErrorResponse.class)
+public interface TraceErrorResponse {
+
+    /**
+     * @return the trace that this error corresponds to
+     */
+    @Schema(requiredMode = RequiredMode.REQUIRED, description = "The trace that this error corresponds to")
+    Trace getTrace();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -162,6 +162,7 @@ public final class EndpointConstants {
     static final String COUNT_EX = "\"" + REQUESTED_TABLE_COUNT_KEY + "\": 100,"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String DIRECTION_EX = "\"" + TABLE_SEARCH_DIRECTION_KEY + "\": \"NEXT\""; //$NON-NLS-1$ //$NON-NLS-2$
     static final String ELEMENT_EX = "\"" + REQUESTED_ELEMENT_KEY + "\": {\"elementType\": \"state\", \"time\": 111100000, \"duration\": 100000}"; //$NON-NLS-1$ //$NON-NLS-2$
+    static final String EXPERIMENT_EX = "{\"name\": \"experiment-1\", ...}"; //$NON-NLS-1$
     static final String EXPRESSIONS_EX = "\"" + TABLE_SEARCH_EXPRESSIONS_KEY + "\": {\"1\": \"cpu.*\"},"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String INDEX_EX = "\"" + REQUESTED_TABLE_INDEX_KEY + "\": 0,"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String ITEMS_EX = "\"" + REQUESTED_ITEMS_KEY + "\": [1, 2]"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -173,11 +174,18 @@ public final class EndpointConstants {
     static final String TIMERANGE_EX_TREE = "\"" + REQUESTED_TIMERANGE_KEY + "\": {\"start\": 111111111, \"end\": 222222222}"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String TIMES_EX_TT = "\"" + REQUESTED_TIME_KEY + "\": [111200000],"; //$NON-NLS-1$ //$NON-NLS-2$
     static final String DP_CFG_EX = "{\"name\": \"Follow My-thread\", \"description\": \"My-thread on even CPUs\", \"typeId\": \"my.config.source.type.id\", \"parameters\":{ \"threads\": \"My-thread\", \"cpus\": [0,2,4,6] }}"; //$NON-NLS-1$
+    static final String TRACE_EX = "{\"name\": \"trace-1\", ...}"; //$NON-NLS-1$
 
     /** Swagger @ApiResponse description constants reused, or centralized. */
     static final String CANNOT_READ = "Cannot read this trace type"; //$NON-NLS-1$
     static final String CONSISTENT_PARENT = "The returned model must be consistent, parentIds must refer to a parent which exists in the model."; //$NON-NLS-1$
-    static final String NAME_EXISTS = "There was already a trace with this name"; //$NON-NLS-1$
+    static final String EXPERIMENT_NAME_EXISTS = "The experiment (name) already exists and both differ."; //$NON-NLS-1$
+    static final String EXPERIMENT_NAME_EXISTS_DETAIL = "The experiment with same name already exists with conflicting parameters. Use a different name to avoid the conflict."; //$NON-NLS-1$
+    static final String NAME_EXISTS = "The trace (name) already exists and both differ"; //$NON-NLS-1$
+    static final String NAME_EXISTS_DETAIL = "The trace with same name already exists with conflicting parameters. Use a different name to avoid the conflict. See error details for conflicting trace."; //$NON-NLS-1$
+    static final String TRACE_IN_USE = "The trace is in use by at least one experiment thus cannot be deleted."; //$NON-NLS-1$
+    static final String TRACE_IN_USE_DETAIL = "Delete all experiements using this trace before deleting the trace."; //$NON-NLS-1$
+
     static final String NOT_SUPPORTED = "Trace type not supported"; //$NON-NLS-1$
     static final String NO_SUCH_EXPERIMENT = "No such experiment"; //$NON-NLS-1$
     static final String PROVIDER_NOT_FOUND = "Experiment or output provider not found"; //$NON-NLS-1$

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ErrorResponseImpl.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ErrorResponseImpl.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response class
+ *
+ * @author Bernd Hufmann
+ */
+public class ErrorResponseImpl implements Serializable {
+
+    private static final long serialVersionUID = -5823094821729001182L;
+
+    private final String fTitle;
+    private final String fDetail;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param title
+     *            The short, human-readable description of the error
+     * @param detail
+     *            The human-readable explanation of the error with details helping the client to correct the error
+     */
+    @JsonCreator
+    public ErrorResponseImpl(
+            @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail) {
+        fTitle = title;
+        fDetail = detail;
+    }
+
+    /**
+     * Constructor with error title only
+     *
+     * @param title
+     *            The short, human-readable description of the error
+     */
+    public ErrorResponseImpl(String title) {
+        this(title, null);
+    }
+
+    /**
+     * Get the short, human-readable description of the error
+     *
+     * @return the error title
+     */
+    @JsonProperty("title")
+    public String getTitle() {
+        return fTitle;
+    }
+
+    /**
+     * Get human-readable explanation of the error with details helping the client to correct the error
+     *
+     * @return the error detail
+     */
+    @JsonProperty("detail")
+    public String getDetail() {
+        return fDetail;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ErrorResponseUtil.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ErrorResponseUtil.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Error response utility class
+ *
+ * @author Bernd Hufmann
+ */
+public class ErrorResponseUtil {
+
+    private ErrorResponseUtil() {
+    }
+
+    /**
+     * Create a new error response
+     *
+     * @param status
+     *            the http status
+     * @param title
+     *            the short-human-readable description of the errors
+     * @return the error response
+     */
+    public static Response newErrorResponse(Status status, String title) {
+        return Response.status(status).entity(new ErrorResponseImpl(title)).build();
+    }
+
+    /**
+     * Create a new error response
+     *
+     * @param status
+     *            the http status
+     * @param title
+     *            the short-human-readable description of the errors
+     * @param detail
+     *            the human-readable explanation of the error helping clients to
+     *            correct the error
+     * @return the error response
+     */
+    public static Response newErrorResponse(Status status, String title, String detail) {
+        return Response.status(status).entity(new ErrorResponseImpl(title, detail)).build();
+    }
+
+    /**
+     * Create a new error response with a trace
+     *
+     * @param status
+     *            the http status
+     * @param title
+     *            the short-human-readable description of the errors
+     * @param detail
+     *            the human-readable explanation of the error helping clients to
+     *            correct the error
+     * @param trace
+     *            the trace this error corresponds to
+     * @return the error response
+     */
+    public static Response newErrorResponse(Status status, String title, String detail, Trace trace) {
+        return Response.status(status).entity(new TraceErrorResponseImpl(title, detail, trace)).build();
+    }
+
+    /**
+     * Create a new error response with an experiment
+     *
+     * @param status
+     *            the http status
+     * @param title
+     *            the short-human-readable description of the errors
+     * @param detail
+     *            the human-readable explanation of the error helping clients to
+     *            correct the error
+     * @param experiment
+     *            the experiment this error corresponds to
+     * @return the error response
+     */
+    public static Response newErrorResponse(Status status, String title, String detail, Experiment experiment) {
+        return Response.status(status).entity(new ExperimentErrorResponseImpl(title, detail, experiment)).build();
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ExperimentErrorResponseImpl.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/ExperimentErrorResponseImpl.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response class with experiment
+ *
+ * @author Bernd Hufmann
+ */
+public class ExperimentErrorResponseImpl extends ErrorResponseImpl {
+
+    private static final long serialVersionUID = -733846016160687714L;
+    private final Experiment fExperiment;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param title
+     *            The short, human-readable description of the error
+     * @param detail
+     *            The human-readable explanation of the error with details helping the client to correct the error
+     * @param experiment
+     *            The experiment this error corresponds to
+     */
+    @JsonCreator
+    public ExperimentErrorResponseImpl(
+            @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail,
+            @JsonProperty("experiment") Experiment experiment) {
+        super(title, detail);
+        fExperiment = experiment;
+    }
+
+    /**
+     * The trace this error corresponds to
+     *
+     * @return The trace this error corresponds to
+     */
+    @JsonProperty("experiment")
+    public Experiment getExperiment() {
+        return fExperiment;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/HealthService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/HealthService.java
@@ -17,6 +17,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ErrorResponse;
 import org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model.ServerStatus;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,7 +48,7 @@ public class HealthService {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get the health status of this server", responses = {
             @ApiResponse(responseCode = "200", description = "The trace server is running and ready to receive requests", content = @Content(schema = @Schema(implementation = ServerStatus.class))),
-            @ApiResponse(responseCode = "503", description = "The trace server is unavailable or in maintenance and cannot receive requests")
+            @ApiResponse(responseCode = "503", description = "The trace server is unavailable or in maintenance and cannot receive requests", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public Response getHealthStatus() {
         // If the server can answer this call, it is up!!

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceErrorResponseImpl.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceErrorResponseImpl.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.services;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Error response class with trace object used for example for conflict error
+ * case.
+ *
+ * @author Bernd Hufmann
+ */
+public class TraceErrorResponseImpl extends ErrorResponseImpl {
+
+    private static final long serialVersionUID = -733846016160687714L;
+    private final Trace fTrace;
+
+    /**
+     * {@link JsonCreator} Constructor for final fields
+     *
+     * @param title
+     *            The short, human-readable description of the error
+     * @param detail
+     *            The human-readable explanation of the error with details helping the client to correct the error
+     * @param trace
+     *            The trace this error corresponds to
+     */
+    @JsonCreator
+    public TraceErrorResponseImpl(
+            @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail,
+            @JsonProperty("trace") Trace trace) {
+        super(title, detail);
+        fTrace = trace;
+    }
+
+    /**
+     * The trace this error corresponds to
+     *
+     * @return the trace this error corresponds to
+     */
+    public Trace getTrace() {
+        return fTrace;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

When an error is created when processing a client request, return an ErrorResponse JSON object that includes
- title: short, human-readable description of the error
- detail: optional, human-readable explanation of the error

This standardizes the error response to common data structure. The field names and purpose are inspired by RFC 9457.

For 409 errors (trace or experiment) return extended ErrorResponse containing the conflicting trace or experiment respectively.

This commit also updates the swagger documentation in respect to the ErrorResponses accordingly.

Contributes to fix issue:

https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/122

### How to test

- Verify using one example use case and see the returned data structure
- Thorough review to make sure that no case was missed.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

Update TSP specification.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
