### PR TITLE
server.test: Support DP capabilities in DataProviderDescriptorStub

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/DataProviderDescriptorStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/DataProviderDescriptorStub.java
@@ -39,6 +39,7 @@ public class DataProviderDescriptorStub implements Serializable {
     private final String fDescription;
     private final String fTypeId;
     private final TmfConfigurationStub fConfiguration;
+    private final TmfCapabilitiesStub fCapabilities;
 
     /**
      * {@link JsonCreator} Constructor for final fields
@@ -55,6 +56,8 @@ public class DataProviderDescriptorStub implements Serializable {
      *            the type id
      * @param configuration
      *            the configuration
+     * @param capabilities
+     *            the data provider capabilities
      *
      */
     @JsonCreator
@@ -63,13 +66,15 @@ public class DataProviderDescriptorStub implements Serializable {
             @JsonProperty("name") String name,
             @JsonProperty("description") String description,
             @JsonProperty("type") String type,
-            @JsonProperty("configuration") TmfConfigurationStub configuration) {
+            @JsonProperty("configuration") TmfConfigurationStub configuration,
+            @JsonProperty("capabilities") TmfCapabilitiesStub capabilities) {
         fParentId = parentId;
         fId = id;
         fName = name;
         fDescription = description;
         fTypeId = type;
         fConfiguration = configuration;
+        fCapabilities = capabilities;
     }
 
     /**
@@ -126,15 +131,24 @@ public class DataProviderDescriptorStub implements Serializable {
         return fConfiguration;
     }
 
+    /**
+     * Gets the capabilities
+     *
+     * @return the capabilities
+     */
+    public TmfCapabilitiesStub getCapabilities() {
+        return fCapabilities;
+    }
+
     @Override
     public String toString() {
         return "DataProviderDescriptorStub[fParentId=" + getParentId() + ", fId=" + getId() + ", fName=" + fName + ", fDescription=" + fDescription
-                + ", fTypeId=" + fTypeId + ", fConfiguration=" + getConfiguration() + "]";
+                + ", fTypeId=" + fTypeId + ", fConfiguration=" + getConfiguration() + ", fCapabilities=" + getCapabilities() + "]";
         }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fParentId, fId, fName, fDescription, fTypeId, fConfiguration);
+        return Objects.hash(fParentId, fId, fName, fDescription, fTypeId, fConfiguration, fCapabilities);
     }
 
     @Override
@@ -166,6 +180,9 @@ public class DataProviderDescriptorStub implements Serializable {
             }
             if (Objects.equals(fConfiguration, other.fConfiguration)) {
                 return true;
+            }
+            if (!Objects.equals(fCapabilities, other.fCapabilities)) {
+                return false;
             }
         }
         return false;

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TmfCapabilitiesStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/TmfCapabilitiesStub.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests.stubs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Basic Implementation of the serialized capabilities model used by clients.
+ *
+ * @author Bernd Hufmann
+ */
+public class TmfCapabilitiesStub {
+
+    private final boolean fCanCreate;
+    private final boolean fCanDelete;
+
+    /**
+     * Constructor
+     *
+     * @param canCreate
+     *            canCreate capability
+     * @param canDelete
+     *            canDelete capability
+     */
+    public TmfCapabilitiesStub(@JsonProperty("canCreate") Boolean canCreate,
+            @JsonProperty("canDelete") Boolean canDelete) {
+        fCanCreate = canCreate == null ? false : canCreate;
+        fCanDelete = canDelete == null ? false : canDelete;
+    }
+
+    /**
+     * @return the canCreate capability
+     */
+    public boolean getCanCreate() {
+        return fCanCreate;
+    }
+
+    /**
+     * @return the canDelete capability
+     */
+    public boolean getCanDelete() {
+        return fCanDelete;
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -260,6 +260,7 @@ public abstract class RestServerTest {
             "Flame Chart",
             "Show a call stack over time",
             ProviderType.TIME_GRAPH.name(),
+            null,
             null);
 
     /**
@@ -392,12 +393,12 @@ public abstract class RestServerTest {
         b.add(new DataProviderDescriptorStub(null, "org.eclipse.tracecompass.internal.analysis.timing.core.segmentstore.scatter.dataprovider:org.eclipse.linuxtools.lttng2.ust.analysis.callstack",
                 "LTTng-UST CallStack - Latency vs Time",
                 "Show latencies provided by Analysis module: LTTng-UST CallStack",
-                ProviderType.TREE_TIME_XY.name(), null));
+                ProviderType.TREE_TIME_XY.name(), null, null));
         b.add(EXPECTED_CALLSTACK_PROVIDER_DESCRIPTOR);
         b.add(new DataProviderDescriptorStub(null,"org.eclipse.tracecompass.internal.tmf.core.histogram.HistogramDataProvider",
                 "Histogram",
                 "Show a histogram of number of events to time for a trace",
-                ProviderType.TREE_TIME_XY.name(), null));
+                ProviderType.TREE_TIME_XY.name(), null, null));
         sfExpectedDataProviderDescriptorStub = b.build();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

This will avoid creating an exception if a DP has data provider capabilities set in the the descriptor when deserializing the descriptor.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

- Create a run configuration in the Eclipse IDE to execute DataProviderServiceTest
- Add the inandout.core plug-in of the incubator to the run configuration
- Execute  DataProviderServiceTest

No exception should be created, in comparison without this patch it will.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
