### PR TITLE
server.test: Fix GenerixXYDataProviderServiceTests failure

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/IAxisDomainStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/IAxisDomainStub.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = IAxisDomainStub.CategoricalStub.class, name = "categorical"),
-    @JsonSubTypes.Type(value = IAxisDomainStub.RangeStub.class, name = "timeRange")
+    @JsonSubTypes.Type(value = IAxisDomainStub.RangeStub.class, name = "range")
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public sealed interface IAxisDomainStub extends Serializable permits


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
server.test: Fix GenerixXYDataProviderServiceTests failure

Commit 0cae21c07a9f47cd3acd0f71a873480623c4be1e introduced a parameter name change that fails the test. That commit was accidentally merged.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful CI

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
