### PR TITLE
swagger: fix parameters definition of Configuration

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Configuration.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/Configuration.java
@@ -11,11 +11,10 @@
 
 package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
 
-import java.util.Map;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.AdditionalPropertiesValue;
 
 /**
  * Contributes to the model used for TSP swagger-core annotations.
@@ -51,6 +50,6 @@ public interface Configuration {
      * @return parameters to return. Can be used to show
      *         more details to users of the configuration instance
      */
-    @Schema(description = "Optional parameters representing the configuration parameters used to create this configuration.")
-    Map<String, Object> getParameters();
+    @Schema(description = "Optional parameters representing the configuration parameters used to create this configuration.", additionalProperties = AdditionalPropertiesValue.TRUE)
+    Object getParameters();
 }


### PR DESCRIPTION
### What it does

swagger: fix parameters definition of Configuration: The generated swagger yaml definition of the parameters field is now a free-form dictionary instead of a map of string to JSON objects.
fixes
https://github.com/eclipse-cdt-cloud/trace-server-protocol/issues/130

### How to test

- Run Trace Server
- In a browser generate the openapi.yaml file by entering (http://localhost:8080/tsp/api/openapi.yaml)
- Open openapi.yaml file and verify that the Configuration specification is a free-form dictionary

### Follow-ups

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
