### PR TITLE
server: Fix incorrect duplicate trace path detection on Windows

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
@@ -203,9 +203,9 @@ public class TraceManagerService {
             }
             resource.setPersistentProperty(TmfCommonConstants.TRACETYPE, traceType);
         } else {
-            IPath targetLocation = getTargetLocation(path);
             IPath oldLocation = ResourceUtil.getLocation(resource);
-            if (oldLocation == null || !targetLocation.equals(oldLocation.removeTrailingSeparator()) ||
+            java.nio.file.Path targetPath = Paths.get(path);
+            if (oldLocation == null || !targetPath.equals(Paths.get(oldLocation.toString())) ||
                     !traceType.equals(resource.getPersistentProperty(TmfCommonConstants.TRACETYPE))) {
                 synchronized (TRACES) {
                     Optional<@NonNull Entry<UUID, IResource>> oldEntry = TRACES.entrySet().stream().filter(entry -> resource.equals(entry.getValue())).findFirst();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Use NIO instead to create Path for old and new trace path in order to compare them, which compares case insensitive.

Fixes #214

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open a trace multiple times, will open the same trace everytime and won't import it under a different name. On Linux the behaviour will be as before, but in Windows the bug is fixed.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
