### PR TITLE
swagger: add TREE_GENERIC_XY enum

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
@@ -22,7 +22,7 @@ public interface DataProvider {
      * The provider types.
      */
     enum ProviderType {
-        TABLE, TREE_TIME_XY, TIME_GRAPH, DATA_TREE, NONE, GANTT_CHART
+        TABLE, TREE_TIME_XY, TIME_GRAPH, DATA_TREE, NONE, GANTT_CHART, TREE_GENERIC_XY
     }
 
     /**
@@ -45,6 +45,7 @@ public interface DataProvider {
             "Providers of type TREE_TIME_XY and TIME_GRAPH can be grouped under the same time axis. " +
             "Providers of type DATA_TREE only provide a tree with columns and don't have any XY nor time graph data associated with it. " +
             "Providers of type GANTT_CHART use the same endpoint as TIME_GRAPH, but have a different x-axis (duration, page faults, etc.), with their own separate ranges. " +
+            "Providers of type TREE_GENERIC_XY supports XY view with non-time x-axis. " +
             "Providers of type NONE have no data to visualize. Can be used for grouping purposes and/or as data provider configurator.")
     ProviderType getType();
 


### PR DESCRIPTION
Add TREE_GENERIC_XY enum that was previously missing.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Add the missing enum in swagger.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run the server and visit http://localhost:8080/tsp/api/openapi.yaml and check that `TREE_GENERIC_XY` is avaiable.

### Follow-ups

Update in `trace-server-protocol`:
[Update in https://github.com/eclipse-cdt-cloud/trace-server-protocol.
](https://github.com/eclipse-cdt-cloud/trace-server-protocol/pull/137)

### Review checklist

- [Y] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
