### PR TITLE
releng: Upgrade target to dependencies of 2025-09 (Eclipse 4.37) release

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="86">
+<target name="tracecompass-incubator-master" sequenceNumber="87">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -13,7 +13,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/releases/12.1/cdt-12.1.0/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.2/cdt-12.2.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -42,6 +42,7 @@
 <unit id="com.google.gson" version="0.0.0"/>
 <unit id="com.google.guava" version="33.4.8.jre"/>
 <unit id="com.sun.xml.bind.jaxb-osgi" version="2.3.9"/>
+<unit id="io.github.classgraph.classgraph"/>
 <unit id="jakarta.activation-api" version="1.2.2"/>
 <unit id="jakarta.annotation-api" version="1.3.5"/>
 <unit id="jakarta.el-api" version="5.0.1"/>
@@ -72,24 +73,24 @@
 <unit id="org.glassfish.hk2.locator.source" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils.source" version="2.6.1"/>
-<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server" version="2.46.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.46.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.46.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.46.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.46.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.46.0"/>
+<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.47.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.47.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.47.0"/>
 <unit id="org.hamcrest" version="0.0.0"/>
 <unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
 <unit id="org.osgi.service.component.annotations" version="0.0.0"/>
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.36.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.37.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -106,7 +107,6 @@
 <unit id="org.eclipse.pde.junit.runtime" version="0.0.0"/>
 <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.equinox.p2.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.test.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
 <unit id="org.eclipse.jdt.core" version="0.0.0"/>
@@ -117,21 +117,25 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.36/R-4.36-202505281830/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.37/R-4.37-202509050730/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.38.0/R-3.38.0-20250601070120/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.39.0/R-3.39.0-20250902093744/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.42.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.43.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/rt/ecf/3.15.5/site.p2/"/>
@@ -153,10 +157,10 @@
 <unit id="org.eclipse.tracecompass.lttng2.control.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.jsontrace.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.tracecompass.tmf.cli.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tracecompass/master/repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/11.1.0/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/tracecompass/master/rcp-repository/"/>
+<repository location="https://download.eclipse.org/tracecompass/releases/11.1.0/rcp-repository/"/>
 <unit id="org.eclipse.tracecompass.rcp.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -166,11 +170,11 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>
+<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.24.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtend.lib" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.35.0/"/>
+<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.40.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ease.feature.feature.group" version="0.0.0"/>
@@ -199,7 +203,7 @@
 			<dependency>
 				<groupId>com.sun.xml.bind</groupId>
 				<artifactId>jaxb-osgi</artifactId>
-				<version>2.3.3</version>
+				<version>4.0.5</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -219,7 +223,7 @@
 			<dependency>
 				<groupId>org.glassfish.jersey.media</groupId>
 				<artifactId>jersey-media-jaxb</artifactId>
-				<version>2.30</version>
+				<version>2.47</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -247,7 +251,7 @@
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2</artifactId>
-				<version>2.2.34</version>
+				<version>2.2.37</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/rcp/org.eclipse.tracecompass.incubator.rcp/feature.xml
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp/feature.xml
@@ -55,7 +55,7 @@
 
    <plugin
          id="jakarta.ws.rs-api"
-         version="0.0.0"/>
+         version="2.1.6"/>
 
    <plugin
          id="org.eclipse.lsp4j"
@@ -135,7 +135,7 @@
 
    <plugin
          id="org.glassfish.jersey.core.jersey-client"
-         version="0.0.0"/>
+         version="2.47.0"/>
 
    <plugin
          id="javassist"
@@ -143,11 +143,11 @@
 
    <plugin
          id="org.glassfish.hk2.locator"
-         version="0.0.0"/>
+         version="2.6.1"/>
 
    <plugin
          id="org.glassfish.hk2.api"
-         version="0.0.0"/>
+         version="2.6.1"/>
 
    <plugin
          id="org.glassfish.hk2.osgi-resource-locator"
@@ -155,7 +155,7 @@
 
    <plugin
          id="org.glassfish.hk2.utils"
-         version="0.0.0"/>
+         version="2.6.1"/>
 
    <plugin
          id="org.aopalliance"
@@ -163,11 +163,11 @@
 
    <plugin
          id="org.glassfish.jersey.core.jersey-common"
-         version="0.0.0"/>
+         version="2.47.0"/>
 
    <plugin
          id="org.glassfish.jersey.inject.jersey-hk2"
-         version="0.0.0"/>
+         version="2.47.0"/>
 
    <plugin
          id="com.google.gson"

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.product/traceserver.product
@@ -111,7 +111,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="com.ibm.icu"/>
       <plugin id="com.sun.jna"/>
       <plugin id="com.sun.jna.platform"/>
-      <plugin id="com.sun.xml.bind.jaxb-osgi"/>
+      <plugin id="com.sun.xml.bind.jaxb-osgi" version="2.3.9"/>
       <plugin id="io.github.classgraph.classgraph"/>
       <plugin id="io.swagger.core.v3.swagger-annotations"/>
       <plugin id="io.swagger.core.v3.swagger-core"/>
@@ -122,7 +122,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="jakarta.annotation-api"/>
       <plugin id="jakarta.servlet-api"/>
       <plugin id="jakarta.validation.jakarta.validation-api"/>
-      <plugin id="jakarta.ws.rs-api"/>
+      <plugin id="jakarta.ws.rs-api" version="2.1.6"/>
       <plugin id="jakarta.xml.bind-api" version="2.3.3"/>
       <plugin id="javassist"/>
       <plugin id="javax.annotation-api"/>
@@ -215,17 +215,17 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.tracecompass.tmf.ctf.core"/>
       <plugin id="org.eclipse.tracecompass.tmf.filter.parser"/>
       <plugin id="org.eclipse.tracecompass.trace-event-logger"/>
-      <plugin id="org.glassfish.hk2.api"/>
-      <plugin id="org.glassfish.hk2.locator"/>
+      <plugin id="org.glassfish.hk2.api" version="2.6.1"/>
+      <plugin id="org.glassfish.hk2.locator" version="2.6.1"/>
       <plugin id="org.glassfish.hk2.osgi-resource-locator"/>
-      <plugin id="org.glassfish.hk2.utils"/>
-      <plugin id="org.glassfish.jersey.containers.jersey-container-servlet-core"/>
-      <plugin id="org.glassfish.jersey.core.jersey-client"/>
-      <plugin id="org.glassfish.jersey.core.jersey-common"/>
-      <plugin id="org.glassfish.jersey.core.jersey-server"/>
-      <plugin id="org.glassfish.jersey.ext.jersey-entity-filtering"/>
-      <plugin id="org.glassfish.jersey.inject.jersey-hk2"/>
-      <plugin id="org.glassfish.jersey.media.jersey-media-json-jackson"/>
+      <plugin id="org.glassfish.hk2.utils" version="2.6.1"/>
+      <plugin id="org.glassfish.jersey.containers.jersey-container-servlet-core" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.core.jersey-client" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.core.jersey-common" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.core.jersey-server" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.ext.jersey-entity-filtering" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.inject.jersey-hk2" version="2.47.0"/>
+      <plugin id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.47.0"/>
       <plugin id="org.hamcrest"/>
       <plugin id="org.hamcrest.core"/>
       <plugin id="org.junit"/>


### PR DESCRIPTION
### What it does

releng: Upgrade target to dependencies of 2025-09 (Eclipse 4.37) release

### How to test

Build with latest target

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
