### PR TITLE
server: Don't index trace when instantiating trace for an experiment

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/TraceManagerService.java
@@ -271,7 +271,6 @@ public class TraceManagerService {
                 String path = Objects.requireNonNull(ResourceUtil.getLocation(resource)).removeTrailingSeparator().toOSString();
                 String name = resource.getName();
                 trace.initTrace(resource, path, ITmfEvent.class, name, typeID);
-                trace.indexTrace(false);
                 // read first event to make sure start time is initialized
                 ITmfContext ctx = trace.seekEvent(0);
                 trace.getNext(ctx);


### PR DESCRIPTION
Indexing will be triggered through the experiment indexing.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
server: Don't index trace when instantiating trace for an experiment. Indexing will be triggered through the experiment indexing.

Needed for https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/pull/324, which requires that no indexing is ongoing when resetting the indexer and trace start/end times during setting of automatic trace transformation. 

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Verify that trace index is created in supplementary directory of server workspace after opening an experiment.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
