### PR TITLE
releng: fix org.glassfish.jersey.media;jersey-media-jaxb version 2.47

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-master" sequenceNumber="87">
+<target name="tracecompass-incubator-master" sequenceNumber="88">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.6/"/>
@@ -223,7 +223,7 @@
 			<dependency>
 				<groupId>org.glassfish.jersey.media</groupId>
 				<artifactId>jersey-media-jaxb</artifactId>
-				<version>3.1.11</version>
+				<version>2.47</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

releng: fix org.glassfish.jersey.media;jersey-media-jaxb version 2.47. The trace server uses Jersey 2.47 and this dependency should match. Otherwise wrong version might be selected in development environment.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful setting updated target in Eclipse IDE and start trace server successfully. 

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
