### PR TITLE
server: Add serializer to serialize TmfXYAxisDescription

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/JacksonObjectMapperProvider.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/JacksonObjectMapperProvider.java
@@ -35,6 +35,7 @@ import org.eclipse.tracecompass.tmf.core.model.timegraph.TimeGraphState;
 import org.eclipse.tracecompass.tmf.core.model.tree.TmfTreeDataModel;
 import org.eclipse.tracecompass.tmf.core.model.xy.ISeriesModel;
 import org.eclipse.tracecompass.tmf.core.model.xy.ITmfXyModel;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -80,6 +81,7 @@ public class JacksonObjectMapperProvider implements ContextResolver<ObjectMapper
             module.addSerializer(ITmfConfigurationSourceType.class, new TmfConfigurationSourceTypeSerializer());
             module.addSerializer(ITmfConfigParamDescriptor.class, new TmfConfigParamDescriptorSerializer());
             module.addSerializer(IAxisDomain.class, new AxisDomainSerializer());
+            module.addSerializer(TmfXYAxisDescription.class, new TmfXYAxisDescriptionSerializer());
 
             // create JsonProvider to provide custom ObjectMapper
             JacksonJaxbJsonProvider provider = new JacksonJaxbJsonProvider();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TmfXYAxisDescriptionSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TmfXYAxisDescriptionSerializer.java
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.webapp;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.tracecompass.tmf.core.model.xy.TmfXYAxisDescription;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Serializer for XY axis description series model {@link TmfXYAxisDescription}
+ *
+ * @author Bernd Hufmann
+ */
+public class TmfXYAxisDescriptionSerializer extends StdSerializer<@NonNull TmfXYAxisDescription> {
+
+    /**
+     * Generated serialVersionUID
+     */
+    private static final long serialVersionUID = 250364996978808548L;
+
+    /**
+     * Constructor.
+     */
+    public TmfXYAxisDescriptionSerializer() {
+        super(TmfXYAxisDescription.class);
+    }
+
+    @Override
+    public void serialize(TmfXYAxisDescription value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField("label", value.getLabel()); //$NON-NLS-1$
+        gen.writeStringField("unit", value.getUnit()); //$NON-NLS-1$
+        gen.writeObjectField("dataType", value.getDataType()); //$NON-NLS-1$
+        if (value.getAxisDomain() != null) {
+            gen.writeObjectField("axisDomain", value.getAxisDomain()); //$NON-NLS-1$
+        }
+        gen.writeEndObject();
+    }
+}


### PR DESCRIPTION
This is to properly serialize optional axisDomain field and not serialize null if not available.

Fixes #234

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
server: Add serializer to serialize TmfXYAxisDescription

This is to properly serialize optional axisDomain field and not serialize null if not available.

Fixes #234

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Follow steps described in #234 and verify that `axisDomain` is not part of the structure in case of the HistogramView. Re-do these steps with `Function Density View` view in `vscode-trace-extension` (needs with LTTng UST trace with callstack trace events) and the model should have a valid `axisDomain` serialized.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
