### PR TITLE
server: Allow lower case strings for time graph tooltip's element type

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/QueryParametersUtil.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/QueryParametersUtil.java
@@ -491,18 +491,21 @@ public class QueryParametersUtil {
         params.computeIfPresent(DataProviderParameterUtils.REQUESTED_ELEMENT_KEY, (k, v) -> {
             if (v instanceof Map) {
                 Map<String, Object> map = (Map<String, Object>) v;
-                Object elementType = map.get(ELEMENT_TYPE);
-                long time = ((Number) map.getOrDefault(TIME, 0L)).longValue();
-                long duration = ((Number) map.getOrDefault(DURATION, 0L)).longValue();
-                if (ElementType.STATE.equals(elementType)) {
-                    return new TimeGraphState(time, duration, null, null);
-                } else if (ElementType.ANNOTATION.equals(elementType)) {
-                    long entryId = ((Number) map.getOrDefault(ENTRY_ID, -1L)).longValue();
-                    return new Annotation(time, duration, entryId, AnnotationType.CHART, null, EMPTY_STYLE);
-                } else if (ElementType.ARROW.equals(elementType)) {
-                    long sourceId = ((Number) map.getOrDefault(ENTRY_ID, -1L)).longValue();
-                    long destinationId = ((Number) map.getOrDefault(DESTINATION_ID, -1L)).longValue();
-                    return new TimeGraphArrow(sourceId, destinationId, time, duration, EMPTY_STYLE);
+                Object elementTypeObj = map.get(ELEMENT_TYPE);
+                if ((elementTypeObj != null)) {
+                    String elementType = elementTypeObj.toString().toLowerCase();
+                    long time = ((Number) map.getOrDefault(TIME, 0L)).longValue();
+                    long duration = ((Number) map.getOrDefault(DURATION, 0L)).longValue();
+                    if (ElementType.STATE.equals(elementType)) {
+                        return new TimeGraphState(time, duration, null, null);
+                    } else if (ElementType.ANNOTATION.equals(elementType)) {
+                        long entryId = ((Number) map.getOrDefault(ENTRY_ID, -1L)).longValue();
+                        return new Annotation(time, duration, entryId, AnnotationType.CHART, null, EMPTY_STYLE);
+                    } else if (ElementType.ARROW.equals(elementType)) {
+                        long sourceId = ((Number) map.getOrDefault(ENTRY_ID, -1L)).longValue();
+                        long destinationId = ((Number) map.getOrDefault(DESTINATION_ID, -1L)).longValue();
+                        return new TimeGraphArrow(sourceId, destinationId, time, duration, EMPTY_STYLE);
+                    }
                 }
             }
             return null;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

server: Allow lower case strings for time graph tooltip's element type.

The TSP specifies that the element type should be upper case (due to enum). This code change will convert the input value to lower case before comparing the actual string. This will allow TSP clients to slowly update to the TSP compliant values.

fixes #240
<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Follow steps in #240 and verify that test are successful.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
