### PR TITLE
server: serialize field `required` as specified in TSP

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ConfigParamDescriptorStub.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/stubs/ConfigParamDescriptorStub.java
@@ -52,7 +52,7 @@ public class ConfigParamDescriptorStub implements Serializable, ITmfConfigParamD
     public ConfigParamDescriptorStub(@JsonProperty("keyName") String keyName,
             @JsonProperty("dataType") String dataType,
             @JsonProperty("description") String description,
-            @JsonProperty("isRequired") Boolean isRequired) {
+            @JsonProperty("required") Boolean isRequired) {
         super();
 
         TmfConfigParamDescriptor.Builder builder = new TmfConfigParamDescriptor.Builder()

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TmfConfigParamDescriptorSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/TmfConfigParamDescriptorSerializer.java
@@ -45,7 +45,7 @@ public class TmfConfigParamDescriptorSerializer extends StdSerializer<ITmfConfig
         gen.writeStringField("keyName", value.getKeyName()); //$NON-NLS-1$
         gen.writeStringField("dataType", value.getDataType()); //$NON-NLS-1$
         gen.writeStringField("description", value.getDescription()); //$NON-NLS-1$
-        gen.writeBooleanField("isRequired", value.isRequired()); //$NON-NLS-1$
+        gen.writeBooleanField("required", value.isRequired()); //$NON-NLS-1$
         gen.writeEndObject();
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Serialize field name as `required` as specified in TSP instead of `isRequired`

fixes #246

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Follow instructions in #246 to verify.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
