### PR TITLE
server: Add support for generic data endpoint

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/DataProvider.java
@@ -23,7 +23,7 @@ public interface DataProvider {
      * The provider types.
      */
     enum ProviderType {
-        TABLE, TREE_TIME_XY, TIME_GRAPH, DATA_TREE, NONE, GANTT_CHART, TREE_GENERIC_XY
+        TABLE, TREE_TIME_XY, TIME_GRAPH, DATA_TREE, GANTT_CHART, TREE_GENERIC_XY, DATA, NONE
     }
 
     /**
@@ -47,6 +47,7 @@ public interface DataProvider {
             "Providers of type DATA_TREE only provide a tree with columns and don't have any XY nor time graph data associated with it. " +
             "Providers of type GANTT_CHART use the same endpoint as TIME_GRAPH, but have a different x-axis (duration, page faults, etc.), with their own separate ranges. " +
             "Providers of type TREE_GENERIC_XY supports XY view with non-time x-axis. " +
+            "Providers of type DATA provide an object with unspecified content. " +
             "Providers of type NONE have no data to visualize. Can be used for grouping purposes and/or as data provider configurator.",
             requiredMode = RequiredMode.REQUIRED)
     ProviderType getType();

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectModel.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectModel.java
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(description = "A generic object with optional navigation parameters. " +
+        "If the next and/or previous navigation parameters are present, one of them can be returned as fetch parameter in a subsequent request to get the following or preceding object.")
+public interface ObjectModel {
+
+    /**
+     * @return The object
+     */
+    @NonNull
+    @Schema(requiredMode = RequiredMode.REQUIRED)
+    Object getObject();
+
+    /**
+     * @return The optional next navigation parameter object
+     */
+    @Nullable
+    @Schema(requiredMode = RequiredMode.NOT_REQUIRED, description = "Navigation object to pass back in next request when browsing forward")
+    Object getNext();
+
+    /**
+     * @return The optional previous navigation parameter object
+     */
+    @Nullable
+    @Schema(requiredMode = RequiredMode.NOT_REQUIRED, description = "Navigation object to pass back in next request when browsing backward")
+    Object getPrevious();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectQueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectQueryParameters.java
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+public interface ObjectQueryParameters {
+
+    /**
+     * @return The parameters.
+     */
+    @NonNull
+    @Schema(requiredMode = RequiredMode.REQUIRED)
+    ObjectParameters getParameters();
+
+    /**
+     * Detailed object parameters
+     */
+    interface ObjectParameters {
+        @JsonProperty("selection_range")
+        @ArraySchema(arraySchema = @Schema( requiredMode = RequiredMode.NOT_REQUIRED, description = "Selection range included when the output has the selectionRange capability" ), minItems = 2, maxItems = 2, schema = @Schema( type = "integer", format = "int64" ))
+        long[] getSelectionRange();
+
+        @JsonProperty("next")
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED, description = "Navigation object passed back from last response when browsing forward")
+        Object getNext();
+
+        @JsonProperty("previous")
+        @Schema(requiredMode = RequiredMode.NOT_REQUIRED, description = "Navigation object passed back from last response when browsing backward")
+        Object getPrevious();
+    }
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectResponse.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/ObjectResponse.java
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (c) 2025 Ericsson
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License 2.0 which
+ * accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+package org.eclipse.tracecompass.incubator.internal.trace.server.jersey.rest.core.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Contributes to the model used for TSP swagger-core annotations.
+ */
+@Schema(allOf = GenericResponse.class)
+public interface ObjectResponse {
+
+    /**
+     * @return The model.
+     */
+    @NonNull
+    ObjectModel getModel();
+}

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputCapabilities.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/OutputCapabilities.java
@@ -33,4 +33,11 @@ public interface OutputCapabilities {
     @Schema(description = "Optional, whether this output (data provider) can be deleted. 'false' if absent.")
     @JsonProperty("canDelete")
     boolean canDelete();
+
+    /**
+     * @return whether this output (data provider) uses the selection range. 'false' if absent.
+     */
+    @Schema(description = "Optional, whether this output (data provider) uses the selection range. 'false' if absent.")
+    @JsonProperty("selectionRange")
+    boolean selectionRange();
 }

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/services/EndpointConstants.java
@@ -99,6 +99,7 @@ public final class EndpointConstants {
     static final String EXP = "Experiments"; //$NON-NLS-1$
     static final String GXY = "Generic XY"; //$NON-NLS-1$
     static final String IDF = "Identifier"; //$NON-NLS-1$
+    static final String OBJ = "Object"; //$NON-NLS-1$
     static final String OCG = "Output Configurations"; //$NON-NLS-1$
     static final String STY = "Styles"; //$NON-NLS-1$
     static final String TGR = "TimeGraph"; //$NON-NLS-1$

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/DataProviderDescriptorSerializer.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/webapp/DataProviderDescriptorSerializer.java
@@ -60,8 +60,15 @@ public class DataProviderDescriptorSerializer extends StdSerializer<IDataProvide
         IDataProviderCapabilities cap = value.getCapabilities();
         if (cap != DataProviderCapabilities.NULL_INSTANCE) {
             gen.writeObjectFieldStart("capabilities"); //$NON-NLS-1$
-            gen.writeBooleanField("canCreate", cap.canCreate()); //$NON-NLS-1$
-            gen.writeBooleanField("canDelete", cap.canDelete()); //$NON-NLS-1$
+            if (cap.canCreate()) {
+                gen.writeBooleanField("canCreate", cap.canCreate()); //$NON-NLS-1$
+            }
+            if (cap.canDelete()) {
+                gen.writeBooleanField("canDelete", cap.canDelete()); //$NON-NLS-1$
+            }
+            if (cap.selectionRange()) {
+                gen.writeBooleanField("selectionRange", cap.selectionRange()); //$NON-NLS-1$
+            }
             gen.writeEndObject();
         }
         gen.writeEndObject();


### PR DESCRIPTION
### What it does

Add support for the /obj endpoint for implementations of IObjectDataProvider.

Add selectionRange to DataProviderCapabilities serializer. Do not serialize capabilities that are false by default.

Update swagger annotations accordingly.

### How to test

Test new /obj endpoint

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
