### PR TITLE
Fix 2024-12 (e4.34) build for generated TSP Java client

### DIFF
--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-e4.34.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="tracecompass-incubator-e4.34" sequenceNumber="4">
+<target name="tracecompass-incubator-e4.34" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <repository location="https://download.eclipse.org/justj/jres/17/updates/release/17.0.14/"/>
@@ -25,20 +25,6 @@
 <unit id="bcpg" version="0.0.0"/>
 <unit id="bcprov" version="0.0.0"/>
 <unit id="ch.qos.logback.classic" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-annotations.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-core.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.core.jackson-databind.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider.source" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0"/>
-<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations.source" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
 <unit id="com.google.guava" version="33.3.1.jre"/>
 <unit id="com.sun.xml.bind.jaxb-osgi" version="2.3.9"/>
@@ -63,30 +49,48 @@
 <unit id="org.apache.commons.math3" version="0.0.0"/>
 <unit id="org.apache.xml.serializer" version="0.0.0"/>
 <unit id="org.eclipse.jetty.servlet-api" version="0.0.0"/>
+<unit id="org.hamcrest" version="0.0.0"/>
+<unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
+<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
+<unit id="slf4j.api" version="0.0.0"/>
+<unit id="slf4j.simple" version="0.0.0"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-annotations.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-core.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.core.jackson-databind.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider.source" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0"/>
+<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations.source" version="0.0.0"/>
+<unit id="io.github.classgraph.classgraph"/>
 <unit id="org.glassfish.hk2.api" version="2.6.1"/>
 <unit id="org.glassfish.hk2.api.source" version="2.6.1"/>
 <unit id="org.glassfish.hk2.locator" version="2.6.1"/>
 <unit id="org.glassfish.hk2.locator.source" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils" version="2.6.1"/>
 <unit id="org.glassfish.hk2.utils.source" version="2.6.1"/>
-<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server" version="2.45.0"/>
-<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.45.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.45.0"/>
-<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.45.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.45.0"/>
-<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.45.0"/>
-<unit id="org.hamcrest" version="0.0.0"/>
-<unit id="org.mortbay.jasper.apache-jsp" version="0.0.0"/>
-<unit id="org.osgi.service.component.annotations" version="0.0.0"/>
-<unit id="slf4j.api" version="0.0.0"/>
-<unit id="slf4j.simple" version="0.0.0"/>
+<unit id="org.glassfish.jersey.containers.jersey-container-servlet" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-client.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-common.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server" version="2.47.0"/>
+<unit id="org.glassfish.jersey.core.jersey-server.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2" version="2.47.0"/>
+<unit id="org.glassfish.jersey.inject.jersey-hk2.source" version="2.47.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.47.0"/>
+<unit id="org.glassfish.jersey.media.jersey-media-json-jackson.source" version="2.47.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.34.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.37.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -237,7 +241,7 @@
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
 				<artifactId>swagger-jaxrs2</artifactId>
-				<version>2.2.19</version>
+				<version>2.2.37</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -250,6 +254,26 @@
 				<version>0.4.0</version>
 				<type>jar</type>
 			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.glassfish.jersey.media</groupId>
+				<artifactId>jersey-media-multipart</artifactId>
+				<version>2.47</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
+	</location>
+	<location includeDependencyDepth="infinite" includeDependencyScopes="provided,compile,system,runtime" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>com.google.code.findbugs</groupId>
+				<artifactId>jsr305</artifactId>
+				<version>3.0.2</version>
+				<type>jar</type>
+ 			</dependency>
 		</dependencies>
 	</location>
 </locations>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

The TSP Java Client generated by openapi-generator-maven-plugin maven plugin, version 7.15.0 requires a newer version of Jackson than the original e4.34 target was providing.

Update the tracecompass-incubator-e4.34.target for this hence the Trace Server RCP with targed will use a newer Jackson version as well.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Successful build with e4.34 target from the incubator git repository:
```bash
cp -f trace-server/org.eclipse.tracecompass.incubator.trace.server.product/legacy-e4.34/traceserver.product trace-server/org.eclipse.tracecompass.incubator.trace.server.product/
mvn clean install -Dtarget-platform=tracecompass-incubator-e4.34 -Djdk.version=17 -Djdk.release=17 -DskipTests=true
```

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
