### PR TITLE
server: Fix handling of null parameters

### DIFF
--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core.tests/src/org/eclipse/tracecompass/incubator/trace/server/jersey/rest/core/tests/utils/RestServerTest.java
@@ -119,9 +119,19 @@ public abstract class RestServerTest {
     protected static final Comparator<DataProvider> DP_COMPARATOR = (p1, p2) -> p1.getName().compareTo(p2.getName());
 
     /**
+     * the Query parameters key for "parameters"
+     */
+    protected static final String PARAMETER_KEY = "parameters";
+
+    /**
      * No parameter string
      */
     protected static final String NO_PARAMETERS = "no-parameters";
+
+    /**
+     * Parameters with null parameter value
+     */
+    protected static final Map<String, Object> NULL_PARAMETERS = Collections.singletonMap(PARAMETER_KEY, null);
 
     /**
      * Invalid experiment UUID
@@ -1133,9 +1143,23 @@ public abstract class RestServerTest {
         if (hasParameters) {
             // Missing parameters
             endpoint = resolver.getEndpoint(expUuid.toString(), dpId);
+            try (Response response = endpoint.request().post(Entity.json(NULL_PARAMETERS))) {
+                assertNotNull(response);
+                assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            }
+
+            // Missing parameters
+            endpoint = resolver.getEndpoint(expUuid.toString(), dpId);
             try (Response response = endpoint.request().post(Entity.json(new QueryParameters(parameters, Collections.emptyList())))) {
                 assertNotNull(response);
                 assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            }
+        } else {
+            // Test null parameters. Since endpoint doesn't require parameters, this should not cause an error reply
+            endpoint = resolver.getEndpoint(expUuid.toString(), dpId);
+            try (Response response = endpoint.request().post(Entity.json(NULL_PARAMETERS))) {
+                assertNotNull(response);
+                assertEquals(Status.OK.getStatusCode(), response.getStatus());
             }
         }
 

--- a/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/QueryParameters.java
+++ b/trace-server/org.eclipse.tracecompass.incubator.trace.server.jersey.rest.core/src/org/eclipse/tracecompass/incubator/internal/trace/server/jersey/rest/core/model/views/QueryParameters.java
@@ -26,7 +26,7 @@ import io.swagger.v3.oas.annotations.Hidden;
  * @author Simon Delisle
  */
 public class QueryParameters {
-    private @NonNull Map<String, Object> parameters;
+    private @Nullable Map<String, Object> parameters;
     private List<Filter> filters;
 
     /**
@@ -55,7 +55,13 @@ public class QueryParameters {
      */
     @Hidden
     public @NonNull Map<String, Object> getParameters() {
-        return parameters;
+        // Treat null parameters sent by the client as empty parameters map
+        Map<String, Object> params = parameters;
+        if (params == null) {
+            params = new HashMap<>();
+            parameters = params;
+        }
+        return params ;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Handle null parameters as empty parameters map and let the endpoints handle execute handling of the empty parameters.

Fixes #235

<!-- Include relevant issues and describe how they are addressed. -->

### How to test
The PR contains the updated unit tests to test the handling of null parameters map. This can be used to verify the PR. 

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups
N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
