### PR TITLE
callstack: Add case to handle nestable instant events

### DIFF
--- a/tracetypes/org.eclipse.tracecompass.incubator.traceevent.core/src/org/eclipse/tracecompass/incubator/internal/traceevent/core/analysis/callstack/TraceEventCallStackProvider.java
+++ b/tracetypes/org.eclipse.tracecompass.incubator.traceevent.core/src/org/eclipse/tracecompass/incubator/internal/traceevent/core/analysis/callstack/TraceEventCallStackProvider.java
@@ -61,7 +61,7 @@ import org.eclipse.tracecompass.tmf.core.trace.TmfTraceUtils;
 public class TraceEventCallStackProvider extends CallStackStateProvider {
 
     private static final String ASYNC_SUFFIX = "(async)"; //$NON-NLS-1$
-    private static final int VERSION_NUMBER = 9;
+    private static final int VERSION_NUMBER = 10;
     private static final int UNSET_ID = -1;
     static final String EDGES = "EDGES"; //$NON-NLS-1$
 
@@ -266,6 +266,9 @@ public class TraceEventCallStackProvider extends CallStackStateProvider {
             return;
         }
         switch (ph) {
+        case TraceEventPhases.NESTABLE_INSTANT:
+            handleInstant(event, ss, timestamp, processName);
+            break;
         case TraceEventPhases.INSTANT:
             handleInstant(event, ss, timestamp, processName);
             break;


### PR DESCRIPTION

### What it does

Show markers for nestable instant events

### How to test

- run the incubator
- load the following trace:

{
  "traceEvents":  [
    {
      "name": "HandleRequest",
      "cat": "server",
      "ph": "B",
      "ts": 1000000,
      "pid": 1,
      "tid": 10,
      "args": {
        "endpoint": "/api/user"
      }
    },
    {
      "name": "ParseJSON",
      "cat": "server",
      "ph": "B",
      "ts": 1000100,
      "pid": 1,
      "tid": 10
    },
    {
      "name": "json_parse_step",
      "cat": "parser",
      "ph": "n",
      "ts": 1000120,
      "pid": 1,
      "tid": 10,
      "id": "0xabc",
      "args": {
        "key": "user_id",
        "value_type": "string"
      }
    },
    {
      "name": "ParseJSON",
      "cat": "server",
      "ph": "E",
      "ts": 1000300,
      "pid": 1,
      "tid": 10
    },
    {
      "name": "QueryDatabase",
      "cat": "database",
      "ph": "B",
      "ts": 1000400,
      "pid": 1,
      "tid": 10,
      "args": {
        "query": "SELECT * FROM users WHERE id=?"
      }
    },
    {
      "name": "QueryDatabase",
      "cat": "database",
      "ph": "E",
      "ts": 1000800,
      "pid": 1,
      "tid": 10
    },
    {
      "name": "HandleRequest",
      "cat": "server",
      "ph": "E",
      "ts": 1001000,
      "pid": 1,
      "tid": 10
    }
  ]

}


### Follow-ups

### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
