### PR TITLE
releng: Upgrade target to dependencies of 2026-03 (Eclipse 4.39) release

### DIFF
--- a/analyses/org.eclipse.tracecompass.incubator.filters.core/src/org/eclipse/tracecompass/incubator/internal/filters/core/client/LanguageFilterClient.java
+++ b/analyses/org.eclipse.tracecompass.incubator.filters.core/src/org/eclipse/tracecompass/incubator/internal/filters/core/client/LanguageFilterClient.java
@@ -46,7 +46,7 @@ import org.eclipse.tracecompass.incubator.internal.filters.core.shared.LspObserv
 /**
  * The LanguageFilterClient implementation for the FilterBox
  *
- * See LSP specifications for more informations.
+ * See LSP specifications for more information.
  *
  * @author Maxime Thibault
  *
@@ -97,7 +97,7 @@ public class LanguageFilterClient implements LanguageClient, LspObservable {
 
     /**
      * Task to ask the server for autocompletion hints. Then update the dropdown
-     * sugestions
+     * suggestions
      *
      * @param uri
      *            For a text document this would be a path to the file. In order
@@ -180,7 +180,7 @@ public class LanguageFilterClient implements LanguageClient, LspObservable {
     }
 
     /**
-     * Tell the server that the document at uri has been open
+     * Tell the server that the document at uri has been opened
      *
      * @param uri
      */
@@ -193,7 +193,7 @@ public class LanguageFilterClient implements LanguageClient, LspObservable {
     }
 
     /**
-     * Tell the server that the document at uri as change.
+     * Tell the server that the document at uri has changed.
      *
      * @param uri
      * @param input
@@ -211,7 +211,7 @@ public class LanguageFilterClient implements LanguageClient, LspObservable {
         Position p1 = new Position(0, min);
         Position p2 = new Position(0, max);
         Range r = new Range(p1, p2);
-        TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(r, max + 1, input);
+        TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent(r, input);
         List<TextDocumentContentChangeEvent> changelist = new ArrayList<>();
         changelist.add(change);
         VersionedTextDocumentIdentifier filterBoxId = new VersionedTextDocumentIdentifier();

--- a/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
+++ b/common/org.eclipse.tracecompass.incubator.target/tracecompass-incubator-master.target
@@ -3,7 +3,7 @@
 <target name="tracecompass-incubator-master" sequenceNumber="90">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.9/"/>
+<repository location="https://download.eclipse.org/justj/jres/21/updates/release/21.0.10/"/>
 <unit id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -12,7 +12,7 @@
 <unit id="org.eclipse.remote.ui" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.core" version="0.0.0"/>
 <unit id="org.eclipse.remote.jsch.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/cdt/releases/12.3/cdt-12.3.0/"/>
+<repository location="https://download.eclipse.org/tools/cdt/releases/12.4/cdt-12.4.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -88,7 +88,7 @@
 <unit id="slf4j.api" version="0.0.0"/>
 <unit id="slf4j.simple" version="0.0.0"/>
 <unit id="org.yaml.snakeyaml" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.38.0/"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.39.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mozilla.javascript" version="0.0.0"/>
@@ -115,28 +115,26 @@
 <unit id="org.eclipse.jdt.junit4.runtime" version="0.0.0"/>
 <unit id="org.eclipse.e4.ui.progress" version="0.0.0"/>
 <unit id="org.eclipse.osgi.services" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.38/R-4.38-202512010920/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.39/R-4.39-202602260420/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.wst.xml.core" version="0.0.0"/>
 <unit id="org.eclipse.wst.xml.ui" version="0.0.0"/>
 <unit id="org.eclipse.wst.xsd.core" version="0.0.0"/>
-<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.40.0/R-3.40.0-20251124015847/repository/"/>
+<repository location="https://download.eclipse.org/webtools/downloads/drops/R3.41.0/R-3.41.0-20260225091541/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xsd" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.44.0/"/>
+<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.45.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.ecf.filetransfer.httpclientjava.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/rt/ecf/3.15.5/site.p2/"/>
+<repository location="https://download.eclipse.org/rt/ecf/3.16.2/site.p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtchart.feature.feature.group" version="0.0.0"/>
@@ -168,11 +166,11 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.24.0/"/>
+<repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtend.lib" version="0.0.0"/>
-<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.40.0/"/>
+<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.42.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ease.feature.feature.group" version="0.0.0"/>

--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product
@@ -137,8 +137,6 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.tmf.ctf"/>
       <feature id="org.eclipse.tracecompass.tmf.cli"/>
       <feature id="org.eclipse.tracecompass.tmf.pcap"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature"/>
       <feature id="org.eclipse.ecf.core.feature"/>
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.tracecompass.incubator.virtual.machine.analysis"/>


### PR DESCRIPTION
### What it does

filters.core: Fix issue to make the build work
releng: Upgrade target to dependencies of 2026-03 (Eclipse 4.39) release

### How to test

Set up Trace Compass with Incubator plugins, compile and run.

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated build platform dependencies to latest stable versions
  - Removed unused SSL-related connectivity features from product distribution
  - Corrected documentation text in language filter client

<!-- end of auto-generated comment: release notes by coderabbit.ai -->