### PR TITLE
releng: add legacy product for 2024-12 build

### DIFF
--- a/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy-e4.34/tracing.incubator.product
+++ b/rcp/org.eclipse.tracecompass.incubator.rcp.product/legacy-e4.34/tracing.incubator.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Trace Compass (Incubator)" uid="org.eclipse.tracecompass.incubator.rcp" id="org.eclipse.tracecompass.incubator.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="0.17.0.qualifier" useFeatures="true" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Trace Compass (Incubator)" uid="org.eclipse.tracecompass.incubator.rcp" id="org.eclipse.tracecompass.incubator.rcp.branding.product" application="org.eclipse.tracecompass.rcp.ui.application" version="0.17.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.tracecompass.incubator.rcp.branding/icons/tc_about.png"/>
@@ -29,11 +29,11 @@ SPDX-License-Identifier: EPL-2.0
       </programArgs>
       <programArgsLin>--launcher.GTK_version 3
       </programArgsLin>
-      <vmArgsLin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=11
+      <vmArgsLin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=17
       </vmArgsLin>
-      <vmArgsMac>-Xms512m -Xmx1024m -XstartOnFirstThread -Dosgi.requiredJavaVersion=11 -Dorg.eclipse.swt.internal.carbon.smallFonts
+      <vmArgsMac>-Xms512m -Xmx1024m -XstartOnFirstThread -Dosgi.requiredJavaVersion=17 -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
-      <vmArgsWin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=11
+      <vmArgsWin>-Xms512m -Xmx1024m  -Dosgi.requiredJavaVersion=17
       </vmArgsWin>
    </launcherArgs>
 
@@ -51,10 +51,10 @@ SPDX-License-Identifier: EPL-2.0
    </launcher>
 
    <vm>
-      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
-      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</macos>
       <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</solaris>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17</windows>
    </vm>
 
    <license>
@@ -144,7 +144,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.virtual.machine.analysis"/>
       <feature id="org.eclipse.tracecompass.incubator.rcp.branding.feature"/>
       <feature id="org.eclipse.tracecompass.incubator.atrace"/>
-      <feature id="org.eclipse.tracecompass.incubator.callstack"/>
+      <feature id="org.eclipse.tracecompass.incubator.analysis"/>
       <feature id="org.eclipse.tracecompass.incubator.eventfieldcount"/>
       <feature id="org.eclipse.tracecompass.incubator.executioncomparison"/>
       <feature id="org.eclipse.tracecompass.incubator.ftrace"/>
@@ -155,13 +155,15 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.opentracing"/>
       <feature id="org.eclipse.tracecompass.incubator.perf.profiling"/>
       <feature id="org.eclipse.tracecompass.incubator.ros"/>
+      <feature id="org.eclipse.tracecompass.incubator.ros2"/>
       <feature id="org.eclipse.tracecompass.incubator.rocm"/>
       <feature id="org.eclipse.tracecompass.incubator.tracecompass"/>
       <feature id="org.eclipse.tracecompass.incubator.traceevent"/>
       <feature id="org.eclipse.tracecompass.incubator.uftrace"/>
       <feature id="org.eclipse.tracecompass.incubator.gpu"/>
       <feature id="org.eclipse.tracecompass.incubator.tmf.ui.multiview"/>
-      <feature id="org.eclipse.ecf.filetransfer.httpclient45.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.httpclient5.feature"/>
+      <feature id="org.eclipse.ecf.filetransfer.httpclientjava.feature"/>
       <feature id="org.eclipse.tracecompass.jsontrace" installMode="root"/>
       <feature id="org.eclipse.tracecompass.rcp" installMode="root"/>
       <feature id="org.eclipse.tracecompass.incubator.rcp" installMode="root"/>
@@ -170,6 +172,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <feature id="org.eclipse.tracecompass.incubator.scripting" installMode="root"/>
       <feature id="org.eclipse.tracecompass.incubator.scripting.javascript" installMode="root"/>
       <feature id="org.eclipse.tracecompass.incubator.scripting.python" installMode="root"/>
+      <feature id="org.eclipse.tracecompass.incubator.dpdk" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.minimal.stripped" installMode="root"/>
    </features>
 
    <configurations>
@@ -184,8 +188,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
    </configurations>
 
    <repositories>
-      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" enabled="true" />
-      <repository location="https://download.eclipse.org/tracecompass.incubator/master/repository" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass/master/rcp-repository" name="" enabled="true" />
+      <repository location="https://download.eclipse.org/tracecompass.incubator/master/repository" name="" enabled="true" />
    </repositories>
 
    <preferencesInfo>


### PR DESCRIPTION
### What it does

releng: add legacy product that was modified in PR #267.

### How to test

Run the build with legacy product

### Follow-ups

N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Trace Compass (Incubator)" product (v0.17.0) with platform-specific launchers, Java 17 requirement, bundled UI assets (icons/splash/about), and preselected feature installation for a ready-to-run RCP experience.
* **Chores**
  * Switched update/repository endpoints to HTTPS for secure installs and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->